### PR TITLE
Add deal expiration and search self-filtering (#9, #11)

### DIFF
--- a/src/__tests__/cleanup.test.ts
+++ b/src/__tests__/cleanup.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { cleanupExpiredDeals, cleanupInactiveProfiles } from "@/lib/cleanup";
+import { createTestDb, _setDb } from "@/lib/db";
+import type Database from "better-sqlite3";
+
+let db: Database.Database;
+let restore: () => void;
+
+beforeEach(() => {
+  db = createTestDb();
+  restore = _setDb(db);
+});
+
+afterEach(() => {
+  restore();
+  db.close();
+});
+
+function insertProfile(
+  agentId: string,
+  side: "offering" | "seeking",
+  category: string,
+  createdAt?: string
+): string {
+  const id = crypto.randomUUID();
+  db.prepare(
+    "INSERT INTO profiles (id, agent_id, side, category, params, created_at) VALUES (?, ?, ?, ?, '{}', ?)"
+  ).run(id, agentId, side, category, createdAt ?? new Date().toISOString().replace("T", " ").slice(0, 19));
+  return id;
+}
+
+function insertMatch(
+  profileAId: string,
+  profileBId: string,
+  status: string,
+  expiresAt: string
+): string {
+  const id = crypto.randomUUID();
+  db.prepare(
+    "INSERT INTO matches (id, profile_a_id, profile_b_id, overlap_summary, status, expires_at) VALUES (?, ?, ?, '{}', ?, ?)"
+  ).run(id, profileAId, profileBId, status, expiresAt);
+  return id;
+}
+
+function pastDate(daysAgo: number): string {
+  return new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000)
+    .toISOString().replace("T", " ").slice(0, 19);
+}
+
+function futureDate(daysAhead: number): string {
+  return new Date(Date.now() + daysAhead * 24 * 60 * 60 * 1000)
+    .toISOString().replace("T", " ").slice(0, 19);
+}
+
+describe("cleanupExpiredDeals", () => {
+  it("expires matched deals past their expiry date", () => {
+    const pA = insertProfile("alice", "offering", "dev");
+    const pB = insertProfile("bob", "seeking", "dev");
+    insertMatch(pA, pB, "matched", pastDate(1));
+
+    const count = cleanupExpiredDeals();
+    expect(count).toBe(1);
+
+    const row = db.prepare("SELECT status FROM matches").get() as { status: string };
+    expect(row.status).toBe("expired");
+  });
+
+  it("expires negotiating deals past their expiry date", () => {
+    const pA = insertProfile("alice", "offering", "dev");
+    const pB = insertProfile("bob", "seeking", "dev");
+    insertMatch(pA, pB, "negotiating", pastDate(1));
+
+    const count = cleanupExpiredDeals();
+    expect(count).toBe(1);
+  });
+
+  it("does NOT expire approved deals", () => {
+    const pA = insertProfile("alice", "offering", "dev");
+    const pB = insertProfile("bob", "seeking", "dev");
+    insertMatch(pA, pB, "approved", pastDate(1));
+
+    const count = cleanupExpiredDeals();
+    expect(count).toBe(0);
+
+    const row = db.prepare("SELECT status FROM matches").get() as { status: string };
+    expect(row.status).toBe("approved");
+  });
+
+  it("does NOT expire rejected deals", () => {
+    const pA = insertProfile("alice", "offering", "dev");
+    const pB = insertProfile("bob", "seeking", "dev");
+    insertMatch(pA, pB, "rejected", pastDate(1));
+
+    const count = cleanupExpiredDeals();
+    expect(count).toBe(0);
+
+    const row = db.prepare("SELECT status FROM matches").get() as { status: string };
+    expect(row.status).toBe("rejected");
+  });
+
+  it("does NOT expire deals that haven't reached their expiry", () => {
+    const pA = insertProfile("alice", "offering", "dev");
+    const pB = insertProfile("bob", "seeking", "dev");
+    insertMatch(pA, pB, "matched", futureDate(3));
+
+    const count = cleanupExpiredDeals();
+    expect(count).toBe(0);
+
+    const row = db.prepare("SELECT status FROM matches").get() as { status: string };
+    expect(row.status).toBe("matched");
+  });
+
+  it("handles multiple deals correctly", () => {
+    const pA = insertProfile("alice", "offering", "dev");
+    const pB = insertProfile("bob", "seeking", "dev");
+    const pC = insertProfile("charlie", "seeking", "dev");
+
+    insertMatch(pA, pB, "matched", pastDate(1));       // should expire
+    insertMatch(pA, pC, "approved", pastDate(1));       // should NOT expire
+
+    const count = cleanupExpiredDeals();
+    expect(count).toBe(1);
+  });
+});
+
+describe("cleanupInactiveProfiles", () => {
+  it("deactivates profiles with no activity past the threshold", () => {
+    insertProfile("alice", "offering", "dev", pastDate(60));
+
+    const count = cleanupInactiveProfiles(30);
+    expect(count).toBe(1);
+
+    const row = db.prepare("SELECT active FROM profiles").get() as { active: number };
+    expect(row.active).toBe(0);
+  });
+
+  it("keeps recent profiles active", () => {
+    insertProfile("alice", "offering", "dev"); // created now
+
+    const count = cleanupInactiveProfiles(30);
+    expect(count).toBe(0);
+
+    const row = db.prepare("SELECT active FROM profiles").get() as { active: number };
+    expect(row.active).toBe(1);
+  });
+
+  it("keeps profiles with recent match activity", () => {
+    const pA = insertProfile("alice", "offering", "dev", pastDate(60));
+    const pB = insertProfile("bob", "seeking", "dev", pastDate(60));
+
+    // Recent match activity
+    insertMatch(pA, pB, "matched", futureDate(7));
+
+    const count = cleanupInactiveProfiles(30);
+    // Both profiles have recent match activity
+    expect(count).toBe(0);
+  });
+
+  it("does not deactivate already-inactive profiles", () => {
+    const id = insertProfile("alice", "offering", "dev", pastDate(60));
+    db.prepare("UPDATE profiles SET active = 0 WHERE id = ?").run(id);
+
+    const count = cleanupInactiveProfiles(30);
+    expect(count).toBe(0);
+  });
+});

--- a/src/app/api/cleanup/route.ts
+++ b/src/app/api/cleanup/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import { cleanupExpiredDeals, cleanupInactiveProfiles } from "@/lib/cleanup";
+
+/**
+ * POST /api/cleanup - Run housekeeping tasks.
+ * Intended to be called by a cron job or admin trigger.
+ */
+export async function POST() {
+  const expired_deals = cleanupExpiredDeals();
+  const deactivated_profiles = cleanupInactiveProfiles(30);
+
+  return NextResponse.json({ expired_deals, deactivated_profiles });
+}

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -19,6 +19,7 @@ export async function GET(req: NextRequest) {
   const side = searchParams.get("side");
   const skills = searchParams.get("skill")?.split(",").map(s => s.trim().toLowerCase()).filter(Boolean);
   const q = searchParams.get("q");
+  const excludeAgent = searchParams.get("exclude_agent");
   const limit = Math.min(Math.max(parseInt(searchParams.get("limit") ?? "20"), 1), 100);
   const offset = Math.max(parseInt(searchParams.get("offset") ?? "0"), 0);
 
@@ -45,6 +46,11 @@ export async function GET(req: NextRequest) {
   if (q) {
     conditions.push("description LIKE ?");
     params.push(`%${q}%`);
+  }
+
+  if (excludeAgent) {
+    conditions.push("agent_id != ?");
+    params.push(excludeAgent);
   }
 
   const whereClause = conditions.join(" AND ");

--- a/src/lib/cleanup.ts
+++ b/src/lib/cleanup.ts
@@ -1,0 +1,47 @@
+import { getDb } from "./db";
+
+/**
+ * Expire matches whose expires_at has passed and are still in an active state.
+ * Returns the number of deals marked as expired.
+ */
+export function cleanupExpiredDeals(): number {
+  const db = getDb();
+  const result = db.prepare(`
+    UPDATE matches
+    SET status = 'expired'
+    WHERE expires_at < datetime('now')
+      AND status NOT IN ('approved', 'rejected', 'expired')
+  `).run();
+  return result.changes;
+}
+
+/**
+ * Deactivate profiles that have had no activity for `daysInactive` days.
+ * Activity is defined as having created a profile, sent a message, or been
+ * part of a match within the window.
+ * Returns the number of profiles deactivated.
+ */
+export function cleanupInactiveProfiles(daysInactive: number): number {
+  const db = getDb();
+  const cutoff = new Date(Date.now() - daysInactive * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .replace("T", " ")
+    .slice(0, 19);
+
+  const result = db.prepare(`
+    UPDATE profiles
+    SET active = 0
+    WHERE active = 1
+      AND created_at < ?
+      AND id NOT IN (
+        SELECT DISTINCT profile_a_id FROM matches WHERE created_at >= ?
+        UNION
+        SELECT DISTINCT profile_b_id FROM matches WHERE created_at >= ?
+      )
+      AND agent_id NOT IN (
+        SELECT DISTINCT sender_agent_id FROM messages WHERE created_at >= ?
+      )
+  `).run(cutoff, cutoff, cutoff, cutoff);
+
+  return result.changes;
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -74,4 +74,11 @@ function migrate(db: Database.Database) {
       UNIQUE(match_id, agent_id)
     );
   `);
+
+  // Add expires_at column to matches (idempotent)
+  try {
+    db.exec(`ALTER TABLE matches ADD COLUMN expires_at TEXT`);
+  } catch {
+    // Column already exists – ignore
+  }
 }

--- a/src/lib/matching.ts
+++ b/src/lib/matching.ts
@@ -27,9 +27,10 @@ export function findMatches(profileId: string): Array<{ matchId: string; counter
       results.push({ matchId: existing.id, counterpart: candidate, overlap });
     } else {
       const matchId = crypto.randomUUID();
+      const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString().replace("T", " ").slice(0, 19);
       db.prepare(
-        "INSERT INTO matches (id, profile_a_id, profile_b_id, overlap_summary) VALUES (?, ?, ?, ?)"
-      ).run(matchId, aId, bId, JSON.stringify(overlap));
+        "INSERT INTO matches (id, profile_a_id, profile_b_id, overlap_summary, expires_at) VALUES (?, ?, ?, ?, ?)"
+      ).run(matchId, aId, bId, JSON.stringify(overlap), expiresAt);
       results.push({ matchId, counterpart: candidate, overlap });
     }
   }


### PR DESCRIPTION
## Summary

Implements deal expiration (#9) and search self-filtering (#11).

### Deal Expiration (#9)
- Added `expires_at` column to `matches` table (migration handles existing DBs gracefully)
- New matches default to 7-day expiry
- `cleanupExpiredDeals()` marks expired matches (skips approved/rejected/already-expired)
- `cleanupInactiveProfiles(30)` deactivates profiles with no activity for 30+ days
- `POST /api/cleanup` endpoint for cron-triggered housekeeping

### Search Self-Filtering (#11)
- Added `exclude_agent` query param to `GET /api/search`
- Agents can exclude their own profiles from search results

### Tests
- 10 new tests covering expiration logic and profile cleanup
- All 53 tests passing

Closes #9, closes #11