### PR TITLE
Add rate limiting (#7)

### DIFF
--- a/src/__tests__/api-auth.test.ts
+++ b/src/__tests__/api-auth.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createTestDb, _setDb } from "@/lib/db";
 import { generateApiKey, hashApiKey, authenticateRequest } from "@/lib/auth";
+import { _resetRateLimitStore } from "@/lib/rate-limit";
 import { POST as keysPOST } from "@/app/api/keys/route";
 import { POST as connectPOST } from "@/app/api/connect/route";
 import { NextRequest } from "next/server";
@@ -10,6 +11,7 @@ let db: Database.Database;
 let restore: () => void;
 
 beforeEach(() => {
+  _resetRateLimitStore();
   db = createTestDb();
   restore = _setDb(db);
 });

--- a/src/__tests__/api-connect.test.ts
+++ b/src/__tests__/api-connect.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createTestDb, _setDb } from "@/lib/db";
+import { _resetRateLimitStore } from "@/lib/rate-limit";
 import type Database from "better-sqlite3";
 import { POST, DELETE } from "@/app/api/connect/route";
 import { POST as keysPOST } from "@/app/api/keys/route";
@@ -9,6 +10,7 @@ let db: Database.Database;
 let restore: () => void;
 
 beforeEach(() => {
+  _resetRateLimitStore();
   db = createTestDb();
   restore = _setDb(db);
 });

--- a/src/__tests__/api-deals.test.ts
+++ b/src/__tests__/api-deals.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createTestDb, _setDb } from "@/lib/db";
+import { _resetRateLimitStore } from "@/lib/rate-limit";
 import type Database from "better-sqlite3";
 import { POST as connectPOST } from "@/app/api/connect/route";
 import { POST as keysPOST } from "@/app/api/keys/route";
@@ -27,6 +28,7 @@ async function getApiKey(agentId: string): Promise<string> {
 }
 
 beforeEach(async () => {
+  _resetRateLimitStore();
   db = createTestDb();
   restore = _setDb(db);
   aliceKey = await getApiKey("alice");

--- a/src/__tests__/rate-limit.test.ts
+++ b/src/__tests__/rate-limit.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import {
+  checkRateLimit,
+  withRateLimit,
+  withKeyGenRateLimit,
+  withWriteRateLimit,
+  withReadRateLimit,
+  _resetRateLimitStore,
+} from "@/lib/rate-limit";
+
+beforeEach(() => {
+  _resetRateLimitStore();
+});
+
+function makeReq(ip: string = "1.2.3.4"): NextRequest {
+  return new NextRequest("http://localhost:3000/api/test", {
+    headers: { "x-forwarded-for": ip },
+  });
+}
+
+describe("checkRateLimit", () => {
+  it("allows requests under the limit", () => {
+    for (let i = 0; i < 5; i++) {
+      const result = checkRateLimit("test-key", 5, 60_000);
+      expect(result.allowed).toBe(true);
+      expect(result.remaining).toBe(5 - i - 1);
+    }
+  });
+
+  it("blocks requests over the limit", () => {
+    for (let i = 0; i < 5; i++) {
+      checkRateLimit("test-key", 5, 60_000);
+    }
+    const result = checkRateLimit("test-key", 5, 60_000);
+    expect(result.allowed).toBe(false);
+    expect(result.remaining).toBe(0);
+    expect(result.retryAfterMs).toBeGreaterThan(0);
+  });
+
+  it("allows requests again after the window expires", () => {
+    // Use a tiny window so timestamps expire immediately
+    const windowMs = 1; // 1 ms
+
+    for (let i = 0; i < 5; i++) {
+      checkRateLimit("expire-key", 5, windowMs);
+    }
+
+    // Wait a couple ms so the window slides past all timestamps
+    const start = Date.now();
+    while (Date.now() - start < 5) {
+      // busy-wait
+    }
+
+    const result = checkRateLimit("expire-key", 5, windowMs);
+    expect(result.allowed).toBe(true);
+  });
+
+  it("uses separate buckets for different keys", () => {
+    for (let i = 0; i < 3; i++) {
+      checkRateLimit("key-a", 3, 60_000);
+    }
+    // key-a is now exhausted
+    expect(checkRateLimit("key-a", 3, 60_000).allowed).toBe(false);
+
+    // key-b should still be fine
+    expect(checkRateLimit("key-b", 3, 60_000).allowed).toBe(true);
+  });
+});
+
+describe("withRateLimit", () => {
+  it("returns null when under the limit", () => {
+    const req = makeReq();
+    const result = withRateLimit(req, 10, 60_000, "test");
+    expect(result).toBeNull();
+  });
+
+  it("returns 429 response when over the limit", async () => {
+    const req = makeReq();
+    for (let i = 0; i < 3; i++) {
+      withRateLimit(req, 3, 60_000, "block-test");
+    }
+
+    const resp = withRateLimit(req, 3, 60_000, "block-test");
+    expect(resp).not.toBeNull();
+    expect(resp!.status).toBe(429);
+
+    const body = await resp!.json();
+    expect(body.error).toContain("Too many requests");
+
+    const retryAfter = resp!.headers.get("Retry-After");
+    expect(retryAfter).toBeTruthy();
+    expect(parseInt(retryAfter!)).toBeGreaterThan(0);
+  });
+
+  it("separates IPs", () => {
+    const reqA = makeReq("10.0.0.1");
+    const reqB = makeReq("10.0.0.2");
+
+    for (let i = 0; i < 2; i++) {
+      withRateLimit(reqA, 2, 60_000, "ip-test");
+    }
+    // A is blocked
+    expect(withRateLimit(reqA, 2, 60_000, "ip-test")).not.toBeNull();
+    // B is fine
+    expect(withRateLimit(reqB, 2, 60_000, "ip-test")).toBeNull();
+  });
+});
+
+describe("preset helpers", () => {
+  it("withKeyGenRateLimit allows 5 then blocks", () => {
+    const req = makeReq("5.5.5.5");
+    for (let i = 0; i < 5; i++) {
+      expect(withKeyGenRateLimit(req)).toBeNull();
+    }
+    expect(withKeyGenRateLimit(req)).not.toBeNull();
+    expect(withKeyGenRateLimit(req)!.status).toBe(429);
+  });
+
+  it("withWriteRateLimit allows 30 then blocks", () => {
+    const req = makeReq("6.6.6.6");
+    for (let i = 0; i < 30; i++) {
+      expect(withWriteRateLimit(req)).toBeNull();
+    }
+    expect(withWriteRateLimit(req)).not.toBeNull();
+  });
+
+  it("withReadRateLimit allows 60 then blocks", () => {
+    const req = makeReq("7.7.7.7");
+    for (let i = 0; i < 60; i++) {
+      expect(withReadRateLimit(req)).toBeNull();
+    }
+    expect(withReadRateLimit(req)).not.toBeNull();
+  });
+});

--- a/src/app/api/cleanup/route.ts
+++ b/src/app/api/cleanup/route.ts
@@ -1,11 +1,14 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { cleanupExpiredDeals, cleanupInactiveProfiles } from "@/lib/cleanup";
+import { withWriteRateLimit } from "@/lib/rate-limit";
 
 /**
  * POST /api/cleanup - Run housekeeping tasks.
  * Intended to be called by a cron job or admin trigger.
  */
-export async function POST() {
+export async function POST(req: NextRequest) {
+  const rateLimited = withWriteRateLimit(req);
+  if (rateLimited) return rateLimited;
   const expired_deals = cleanupExpiredDeals();
   const deactivated_profiles = cleanupInactiveProfiles(30);
 

--- a/src/app/api/connect/[agentId]/route.ts
+++ b/src/app/api/connect/[agentId]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
+import { withReadRateLimit } from "@/lib/rate-limit";
 import type { Profile, ProfileParams } from "@/lib/types";
 
 /**
@@ -11,6 +12,9 @@ export async function GET(
   _req: NextRequest,
   { params }: { params: Promise<{ agentId: string }> }
 ) {
+  const rateLimited = withReadRateLimit(_req);
+  if (rateLimited) return rateLimited;
+
   const { agentId } = await params;
 
   if (!agentId || agentId.trim().length === 0) {

--- a/src/app/api/connect/route.ts
+++ b/src/app/api/connect/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 import { authenticateRequest } from "@/lib/auth";
+import { withWriteRateLimit } from "@/lib/rate-limit";
 import type { ConnectRequest, Side, Profile } from "@/lib/types";
 
 const VALID_SIDES: Side[] = ["offering", "seeking"];
@@ -29,6 +30,9 @@ function validateConnectRequest(body: unknown): { valid: true; data: ConnectRequ
 }
 
 export async function POST(req: NextRequest) {
+  const rateLimited = withWriteRateLimit(req);
+  if (rateLimited) return rateLimited;
+
   const auth = authenticateRequest(req);
   if (!auth) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -75,6 +79,9 @@ export async function POST(req: NextRequest) {
 }
 
 export async function DELETE(req: NextRequest) {
+  const rateLimited = withWriteRateLimit(req);
+  if (rateLimited) return rateLimited;
+
   const auth = authenticateRequest(req);
   if (!auth) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/src/app/api/deals/[matchId]/approve/route.ts
+++ b/src/app/api/deals/[matchId]/approve/route.ts
@@ -1,12 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 import { authenticateRequest } from "@/lib/auth";
+import { withWriteRateLimit } from "@/lib/rate-limit";
 import type { Match, Profile, Approval } from "@/lib/types";
 
 export async function POST(
   req: NextRequest,
   { params }: { params: Promise<{ matchId: string }> }
 ) {
+  const rateLimited = withWriteRateLimit(req);
+  if (rateLimited) return rateLimited;
+
   const auth = authenticateRequest(req);
   if (!auth) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/src/app/api/deals/[matchId]/messages/route.ts
+++ b/src/app/api/deals/[matchId]/messages/route.ts
@@ -1,12 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 import { authenticateRequest } from "@/lib/auth";
+import { withWriteRateLimit } from "@/lib/rate-limit";
 import type { Match, Profile, SendMessageRequest } from "@/lib/types";
 
 export async function POST(
   req: NextRequest,
   { params }: { params: Promise<{ matchId: string }> }
 ) {
+  const rateLimited = withWriteRateLimit(req);
+  if (rateLimited) return rateLimited;
+
   const auth = authenticateRequest(req);
   if (!auth) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/src/app/api/deals/[matchId]/route.ts
+++ b/src/app/api/deals/[matchId]/route.ts
@@ -1,11 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
+import { withReadRateLimit } from "@/lib/rate-limit";
 import type { Match, Message, Approval, Profile } from "@/lib/types";
 
 export async function GET(
   _req: NextRequest,
   { params }: { params: Promise<{ matchId: string }> }
 ) {
+  const rateLimited = withReadRateLimit(_req);
+  if (rateLimited) return rateLimited;
+
   const { matchId } = await params;
 
   const db = getDb();

--- a/src/app/api/deals/route.ts
+++ b/src/app/api/deals/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
+import { withReadRateLimit } from "@/lib/rate-limit";
 
 interface DealRow {
   id: string;
@@ -11,6 +12,9 @@ interface DealRow {
 }
 
 export async function GET(req: NextRequest) {
+  const rateLimited = withReadRateLimit(req);
+  if (rateLimited) return rateLimited;
+
   const { searchParams } = new URL(req.url);
   const agentId = searchParams.get("agent_id");
 

--- a/src/app/api/keys/route.ts
+++ b/src/app/api/keys/route.ts
@@ -1,8 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 import { generateApiKey } from "@/lib/auth";
+import { withKeyGenRateLimit } from "@/lib/rate-limit";
 
 export async function POST(req: NextRequest) {
+  const rateLimited = withKeyGenRateLimit(req);
+  if (rateLimited) return rateLimited;
   let body: unknown;
   try {
     body = await req.json();

--- a/src/app/api/matches/[profileId]/route.ts
+++ b/src/app/api/matches/[profileId]/route.ts
@@ -1,12 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
 import { findMatches } from "@/lib/matching";
 import { getDb } from "@/lib/db";
+import { withReadRateLimit } from "@/lib/rate-limit";
 import type { Profile, ProfileParams } from "@/lib/types";
 
 export async function GET(
   _req: NextRequest,
   { params }: { params: Promise<{ profileId: string }> }
 ) {
+  const rateLimited = withReadRateLimit(_req);
+  if (rateLimited) return rateLimited;
+
   const { profileId } = await params;
 
   if (!profileId || profileId.trim().length === 0) {

--- a/src/app/api/profiles/[profileId]/route.ts
+++ b/src/app/api/profiles/[profileId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 import { authenticateRequest } from "@/lib/auth";
+import { withReadRateLimit, withWriteRateLimit } from "@/lib/rate-limit";
 import type { Profile, ProfileParams } from "@/lib/types";
 
 /**
@@ -11,6 +12,9 @@ export async function GET(
   _req: NextRequest,
   { params }: { params: Promise<{ profileId: string }> }
 ) {
+  const rateLimited = withReadRateLimit(_req);
+  if (rateLimited) return rateLimited;
+
   const { profileId } = await params;
   const db = getDb();
 
@@ -39,6 +43,9 @@ export async function PATCH(
   req: NextRequest,
   { params }: { params: Promise<{ profileId: string }> }
 ) {
+  const rateLimited = withWriteRateLimit(req);
+  if (rateLimited) return rateLimited;
+
   const auth = authenticateRequest(req);
   if (!auth) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
+import { withReadRateLimit } from "@/lib/rate-limit";
 import type { Profile, ProfileParams } from "@/lib/types";
 
 /**
@@ -14,6 +15,9 @@ import type { Profile, ProfileParams } from "@/lib/types";
  *   offset - pagination offset (default 0)
  */
 export async function GET(req: NextRequest) {
+  const rateLimited = withReadRateLimit(req);
+  if (rateLimited) return rateLimited;
+
   const { searchParams } = new URL(req.url);
   const category = searchParams.get("category");
   const side = searchParams.get("side");

--- a/src/app/api/stats/route.ts
+++ b/src/app/api/stats/route.ts
@@ -1,5 +1,6 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
+import { withReadRateLimit } from "@/lib/rate-limit";
 
 /**
  * GET /api/stats - Platform statistics and health check
@@ -7,7 +8,9 @@ import { getDb } from "@/lib/db";
  * Returns counts of profiles, matches, messages, and status breakdown.
  * Useful for monitoring and dashboard display.
  */
-export async function GET() {
+export async function GET(req: NextRequest) {
+  const rateLimited = withReadRateLimit(req);
+  if (rateLimited) return rateLimited;
   const db = getDb();
 
   const profileStats = db.prepare(`

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,144 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * In-memory sliding window rate limiter.
+ *
+ * Each key (typically an IP address) maps to an array of request timestamps.
+ * On each check we drop timestamps outside the current window, then decide
+ * whether to allow or reject the request.
+ */
+
+interface RateLimitEntry {
+  timestamps: number[];
+}
+
+// Global store – lives for the lifetime of the process.
+const store = new Map<string, RateLimitEntry>();
+
+// Periodic cleanup interval (every 60 s) to avoid unbounded memory growth.
+let cleanupTimer: ReturnType<typeof setInterval> | null = null;
+
+function ensureCleanup() {
+  if (cleanupTimer) return;
+  cleanupTimer = setInterval(() => {
+    const now = Date.now();
+    for (const [key, entry] of store) {
+      if (entry.timestamps.length === 0 || entry.timestamps[entry.timestamps.length - 1] < now - 120_000) {
+        store.delete(key);
+      }
+    }
+  }, 60_000);
+  // Allow the process to exit even if the timer is still running.
+  if (typeof cleanupTimer === "object" && "unref" in cleanupTimer) {
+    cleanupTimer.unref();
+  }
+}
+
+/**
+ * Extract a rate-limit key from the request (IP-based).
+ */
+function getKey(req: NextRequest, prefix: string): string {
+  const forwarded = req.headers.get("x-forwarded-for");
+  const ip = forwarded?.split(",")[0]?.trim() ?? "127.0.0.1";
+  return `${prefix}:${ip}`;
+}
+
+export interface RateLimitResult {
+  allowed: boolean;
+  remaining: number;
+  retryAfterMs: number;
+}
+
+/**
+ * Core rate-limit check.
+ *
+ * @param key   – unique key (e.g. "keys:1.2.3.4")
+ * @param limit – max requests allowed in the window
+ * @param windowMs – sliding window size in milliseconds
+ */
+export function checkRateLimit(key: string, limit: number, windowMs: number): RateLimitResult {
+  ensureCleanup();
+
+  const now = Date.now();
+  let entry = store.get(key);
+
+  if (!entry) {
+    entry = { timestamps: [] };
+    store.set(key, entry);
+  }
+
+  // Drop timestamps outside the window
+  const cutoff = now - windowMs;
+  entry.timestamps = entry.timestamps.filter((t) => t > cutoff);
+
+  if (entry.timestamps.length >= limit) {
+    // Earliest timestamp still in the window – that's when a slot opens.
+    const oldest = entry.timestamps[0];
+    const retryAfterMs = oldest + windowMs - now;
+    return { allowed: false, remaining: 0, retryAfterMs: Math.max(retryAfterMs, 1) };
+  }
+
+  entry.timestamps.push(now);
+  return { allowed: true, remaining: limit - entry.timestamps.length, retryAfterMs: 0 };
+}
+
+/**
+ * Helper to call at the top of a Next.js route handler.
+ *
+ * Returns `null` when the request is allowed, or a 429 `NextResponse` when rate-limited.
+ *
+ * @param req      – incoming request
+ * @param limit    – max requests in the window
+ * @param windowMs – sliding window in milliseconds (default 60 000 = 1 minute)
+ * @param prefix   – key namespace (default "global")
+ */
+export function withRateLimit(
+  req: NextRequest,
+  limit: number,
+  windowMs: number = 60_000,
+  prefix: string = "global",
+): NextResponse | null {
+  const key = getKey(req, prefix);
+  const result = checkRateLimit(key, limit, windowMs);
+
+  if (!result.allowed) {
+    const retryAfterSec = Math.ceil(result.retryAfterMs / 1000);
+    return NextResponse.json(
+      { error: "Too many requests. Please try again later." },
+      {
+        status: 429,
+        headers: {
+          "Retry-After": String(retryAfterSec),
+          "X-RateLimit-Limit": String(limit),
+          "X-RateLimit-Remaining": "0",
+        },
+      },
+    );
+  }
+
+  return null; // allowed
+}
+
+// ── Preset helpers ────────────────────────────────────────────────
+
+/** Strict limit for key generation: 5 req / min */
+export function withKeyGenRateLimit(req: NextRequest): NextResponse | null {
+  return withRateLimit(req, 5, 60_000, "keygen");
+}
+
+/** Write endpoints (POST/PATCH/DELETE): 30 req / min */
+export function withWriteRateLimit(req: NextRequest): NextResponse | null {
+  return withRateLimit(req, 30, 60_000, "write");
+}
+
+/** Read endpoints (GET): 60 req / min */
+export function withReadRateLimit(req: NextRequest): NextResponse | null {
+  return withRateLimit(req, 60, 60_000, "read");
+}
+
+/**
+ * Reset the in-memory store. Useful for tests.
+ */
+export function _resetRateLimitStore(): void {
+  store.clear();
+}


### PR DESCRIPTION
Closes #7

- In-memory sliding window rate limiter
- Strict limits on key generation (5/min)
- Standard limits on read (60/min) and write (30/min) endpoints
- 429 responses with Retry-After header
- Tests for rate limiter logic