### PR TITLE
feat: Agent Profile Summary endpoint (GET /api/agents/:agentId/summary)

### DIFF
--- a/src/__tests__/api-agent-summary.test.ts
+++ b/src/__tests__/api-agent-summary.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createTestDb, _setDb, migrate } from "@/lib/db";
+import type { Client } from "@libsql/client";
+import { GET as summaryGET } from "@/app/api/agents/[agentId]/summary/route";
+import { NextRequest } from "next/server";
+
+let db: Client;
+let restore: () => void;
+
+beforeEach(async () => {
+  db = createTestDb();
+  restore = _setDb(db);
+  await migrate(db);
+});
+
+afterEach(() => {
+  restore();
+});
+
+function getReq(url: string): NextRequest {
+  return new NextRequest(`http://localhost:3000${url}`, { method: "GET" });
+}
+
+/** Insert a profile directly in the DB */
+async function insertProfile(
+  agentId: string, side: string, category: string,
+  opts: { description?: string; active?: number; createdAt?: string } = {}
+): Promise<string> {
+  const id = crypto.randomUUID();
+  await db.execute({
+    sql: `INSERT INTO profiles (id, agent_id, side, category, params, description, active, created_at)
+          VALUES (?, ?, ?, ?, '{}', ?, ?, ?)`,
+    args: [
+      id, agentId, side, category,
+      opts.description ?? null,
+      opts.active ?? 1,
+      opts.createdAt ?? new Date().toISOString().replace("T", " ").slice(0, 19),
+    ],
+  });
+  return id;
+}
+
+/** Insert a match directly in the DB */
+async function insertMatch(profileAId: string, profileBId: string, status = "matched"): Promise<string> {
+  const matchId = crypto.randomUUID();
+  const [aId, bId] = profileAId < profileBId ? [profileAId, profileBId] : [profileBId, profileAId];
+  await db.execute({
+    sql: `INSERT INTO matches (id, profile_a_id, profile_b_id, overlap_summary, status)
+          VALUES (?, ?, ?, ?, ?)`,
+    args: [matchId, aId, bId, JSON.stringify({ matching_skills: ["react"], score: 80 }), status],
+  });
+  return matchId;
+}
+
+/** Insert a message directly */
+async function insertMessage(matchId: string, senderAgentId: string, content: string, messageType = "negotiation"): Promise<void> {
+  await db.execute({
+    sql: `INSERT INTO messages (match_id, sender_agent_id, content, message_type) VALUES (?, ?, ?, ?)`,
+    args: [matchId, senderAgentId, content, messageType],
+  });
+}
+
+describe("GET /api/agents/:agentId/summary", () => {
+  it("returns 404 for unknown agent", async () => {
+    const res = await summaryGET(
+      getReq("/api/agents/nobody/summary"),
+      { params: Promise.resolve({ agentId: "nobody" }) }
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns basic summary for agent with one profile", async () => {
+    await insertProfile("alice", "offering", "dev", { description: "I build things" });
+
+    const res = await summaryGET(
+      getReq("/api/agents/alice/summary"),
+      { params: Promise.resolve({ agentId: "alice" }) }
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    expect(data.agent_id).toBe("alice");
+    expect(data.profile_count).toBe(1);
+    expect(data.active_profiles).toHaveLength(1);
+    expect(data.active_profiles[0].side).toBe("offering");
+    expect(data.active_profiles[0].category).toBe("dev");
+    expect(data.active_profiles[0].description).toBe("I build things");
+    expect(data.match_stats.total_matches).toBe(0);
+    expect(data.match_stats.active_deals).toBe(0);
+    expect(data.match_stats.completed_deals).toBe(0);
+    expect(data.match_stats.success_rate).toBe(0);
+    expect(data.recent_activity).toHaveLength(0);
+    expect(data.member_since).toBeTruthy();
+    expect(data.category_breakdown).toEqual({ dev: 1 });
+  });
+
+  it("returns correct match stats", async () => {
+    const offeringId = await insertProfile("alice", "offering", "dev");
+    const seekingId = await insertProfile("bob", "seeking", "dev");
+    await insertMatch(offeringId, seekingId, "matched");
+
+    const res = await summaryGET(
+      getReq("/api/agents/alice/summary"),
+      { params: Promise.resolve({ agentId: "alice" }) }
+    );
+    const data = await res.json();
+
+    expect(data.match_stats.total_matches).toBe(1);
+    expect(data.match_stats.active_deals).toBe(1);
+  });
+
+  it("includes recent activity from messages", async () => {
+    const offeringId = await insertProfile("alice", "offering", "dev");
+    const seekingId = await insertProfile("bob", "seeking", "dev");
+    const matchId = await insertMatch(offeringId, seekingId);
+
+    await insertMessage(matchId, "alice", "Hello Bob!", "negotiation");
+
+    const res = await summaryGET(
+      getReq("/api/agents/alice/summary"),
+      { params: Promise.resolve({ agentId: "alice" }) }
+    );
+    const data = await res.json();
+
+    expect(data.recent_activity).toHaveLength(1);
+    expect(data.recent_activity[0].type).toBe("negotiation");
+    expect(data.recent_activity[0].content).toBe("Hello Bob!");
+    expect(data.recent_activity[0].match_id).toBe(matchId);
+  });
+
+  it("tracks completed deals and success rate", async () => {
+    const a1 = await insertProfile("alice", "offering", "dev");
+    const b1 = await insertProfile("bob", "seeking", "dev");
+    await insertMatch(a1, b1, "approved");
+
+    const a2 = await insertProfile("alice", "offering", "design");
+    const b2 = await insertProfile("bob", "seeking", "design");
+    await insertMatch(a2, b2, "rejected");
+
+    const res = await summaryGET(
+      getReq("/api/agents/alice/summary"),
+      { params: Promise.resolve({ agentId: "alice" }) }
+    );
+    const data = await res.json();
+
+    expect(data.match_stats.total_matches).toBe(2);
+    expect(data.match_stats.completed_deals).toBe(1);
+    expect(data.match_stats.success_rate).toBe(0.5);
+    expect(data.match_stats.active_deals).toBe(0);
+  });
+
+  it("shows category breakdown with multiple categories", async () => {
+    await insertProfile("alice", "offering", "dev");
+    await insertProfile("alice", "seeking", "design");
+
+    const res = await summaryGET(
+      getReq("/api/agents/alice/summary"),
+      { params: Promise.resolve({ agentId: "alice" }) }
+    );
+    const data = await res.json();
+
+    expect(data.profile_count).toBe(2);
+    expect(data.category_breakdown).toEqual({ dev: 1, design: 1 });
+  });
+
+  it("excludes inactive profiles from count but keeps member_since", async () => {
+    await insertProfile("alice", "offering", "dev", { active: 0, createdAt: "2024-01-01 00:00:00" });
+
+    const res = await summaryGET(
+      getReq("/api/agents/alice/summary"),
+      { params: Promise.resolve({ agentId: "alice" }) }
+    );
+    const data = await res.json();
+
+    expect(data.profile_count).toBe(0);
+    expect(data.active_profiles).toHaveLength(0);
+    expect(data.member_since).toBe("2024-01-01 00:00:00");
+  });
+
+  it("limits recent activity to 5 events", async () => {
+    const a = await insertProfile("alice", "offering", "dev");
+    const b = await insertProfile("bob", "seeking", "dev");
+    const matchId = await insertMatch(a, b);
+
+    for (let i = 0; i < 7; i++) {
+      await insertMessage(matchId, "alice", `Message ${i}`);
+    }
+
+    const res = await summaryGET(
+      getReq("/api/agents/alice/summary"),
+      { params: Promise.resolve({ agentId: "alice" }) }
+    );
+    const data = await res.json();
+
+    expect(data.recent_activity).toHaveLength(5);
+  });
+
+  it("only shows messages from the requested agent", async () => {
+    const a = await insertProfile("alice", "offering", "dev");
+    const b = await insertProfile("bob", "seeking", "dev");
+    const matchId = await insertMatch(a, b);
+
+    await insertMessage(matchId, "alice", "From Alice");
+    await insertMessage(matchId, "bob", "From Bob");
+
+    const res = await summaryGET(
+      getReq("/api/agents/alice/summary"),
+      { params: Promise.resolve({ agentId: "alice" }) }
+    );
+    const data = await res.json();
+
+    expect(data.recent_activity).toHaveLength(1);
+    expect(data.recent_activity[0].content).toBe("From Alice");
+  });
+});

--- a/src/app/api/agents/[agentId]/summary/route.ts
+++ b/src/app/api/agents/[agentId]/summary/route.ts
@@ -1,0 +1,120 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import { checkRateLimit, RATE_LIMITS } from "@/lib/rate-limit";
+
+/**
+ * GET /api/agents/:agentId/summary
+ * Public endpoint - returns a consolidated view of an agent's presence.
+ */
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ agentId: string }> }
+) {
+  const rateLimited = checkRateLimit(req, RATE_LIMITS.READ.limit, RATE_LIMITS.READ.windowMs, RATE_LIMITS.READ.prefix);
+  if (rateLimited) return rateLimited;
+
+  const { agentId } = await params;
+
+  if (!agentId || agentId.trim().length === 0) {
+    return NextResponse.json({ error: "agentId is required" }, { status: 400 });
+  }
+
+  const db = getDb();
+
+  // Active profiles
+  const profilesResult = await db.execute({
+    sql: `SELECT id, side, category, description, created_at
+          FROM profiles WHERE agent_id = ? AND active = 1
+          ORDER BY created_at DESC`,
+    args: [agentId],
+  });
+  const profiles = profilesResult.rows as unknown as Array<{
+    id: string; side: string; category: string; description: string | null; created_at: string;
+  }>;
+
+  // member_since: earliest profile created_at (including inactive)
+  const memberSinceResult = await db.execute({
+    sql: `SELECT MIN(created_at) as member_since FROM profiles WHERE agent_id = ?`,
+    args: [agentId],
+  });
+  const memberSince = (memberSinceResult.rows[0] as unknown as { member_since: string | null }).member_since;
+
+  if (!memberSince) {
+    return NextResponse.json({ error: "Agent not found" }, { status: 404 });
+  }
+
+  // All profile IDs for this agent (including inactive, for match stats)
+  const allProfilesResult = await db.execute({
+    sql: `SELECT id FROM profiles WHERE agent_id = ?`,
+    args: [agentId],
+  });
+  const allProfileIds = (allProfilesResult.rows as unknown as Array<{ id: string }>).map(p => p.id);
+
+  let matchStats = { total_matches: 0, active_deals: 0, completed_deals: 0, success_rate: 0 };
+
+  if (allProfileIds.length > 0) {
+    const placeholders = allProfileIds.map(() => "?").join(",");
+    const matchStatsResult = await db.execute({
+      sql: `SELECT
+              COUNT(*) as total_matches,
+              SUM(CASE WHEN status IN ('matched', 'negotiating', 'proposed') THEN 1 ELSE 0 END) as active_deals,
+              SUM(CASE WHEN status = 'approved' THEN 1 ELSE 0 END) as completed_deals,
+              SUM(CASE WHEN status = 'rejected' OR status = 'expired' THEN 1 ELSE 0 END) as failed_deals
+            FROM matches
+            WHERE profile_a_id IN (${placeholders}) OR profile_b_id IN (${placeholders})`,
+      args: [...allProfileIds, ...allProfileIds],
+    });
+    const row = matchStatsResult.rows[0] as unknown as {
+      total_matches: number; active_deals: number; completed_deals: number; failed_deals: number;
+    };
+    const total = Number(row.total_matches);
+    const completed = Number(row.completed_deals);
+    const failed = Number(row.failed_deals);
+    const resolved = completed + failed;
+    matchStats = {
+      total_matches: total,
+      active_deals: Number(row.active_deals),
+      completed_deals: completed,
+      success_rate: resolved > 0 ? Math.round((completed / resolved) * 100) / 100 : 0,
+    };
+  }
+
+  // Recent activity: last 5 messages sent by this agent
+  const recentActivityResult = await db.execute({
+    sql: `SELECT m.match_id, m.content, m.message_type, m.created_at, m.sender_agent_id
+          FROM messages m
+          WHERE m.sender_agent_id = ?
+          ORDER BY m.created_at DESC
+          LIMIT 5`,
+    args: [agentId],
+  });
+  const recentActivity = (recentActivityResult.rows as unknown as Array<{
+    match_id: string; content: string; message_type: string; created_at: string; sender_agent_id: string;
+  }>).map(r => ({
+    match_id: r.match_id,
+    type: r.message_type,
+    content: r.content,
+    created_at: r.created_at,
+  }));
+
+  // Category breakdown
+  const categoryBreakdown: Record<string, number> = {};
+  for (const p of profiles) {
+    categoryBreakdown[p.category] = (categoryBreakdown[p.category] || 0) + 1;
+  }
+
+  return NextResponse.json({
+    agent_id: agentId,
+    profile_count: profiles.length,
+    active_profiles: profiles.map(p => ({
+      id: p.id,
+      side: p.side,
+      category: p.category,
+      description: p.description,
+    })),
+    match_stats: matchStats,
+    recent_activity: recentActivity,
+    member_since: memberSince,
+    category_breakdown: categoryBreakdown,
+  });
+}


### PR DESCRIPTION
## Summary

Implements #17 — adds a public endpoint that returns a consolidated view of an agent's presence on the platform.

### Endpoint

`GET /api/agents/:agentId/summary`

### Response fields

- `agent_id` — the requested agent
- `profile_count` — number of active profiles
- `active_profiles` — list with id, side, category, description
- `match_stats` — total_matches, active_deals, completed_deals, success_rate
- `recent_activity` — last 5 messages sent by the agent
- `member_since` — earliest profile created_at (includes inactive profiles)
- `category_breakdown` — which categories they're active in

### Details

- Public endpoint (no auth required — agents should be discoverable)
- Rate limited using READ preset (60 req/min)
- Returns 404 if agent has never created a profile
- 9 tests covering all response fields, edge cases, and limits

### Tests

```
✓ returns 404 for unknown agent
✓ returns basic summary for agent with one profile
✓ returns correct match stats
✓ includes recent activity from messages
✓ tracks completed deals and success rate
✓ shows category breakdown with multiple categories
✓ excludes inactive profiles from count but keeps member_since
✓ limits recent activity to 5 events
✓ only shows messages from the requested agent
```

Closes #17