### PR TITLE
feat: add deal templates endpoint (#16)

### DIFF
--- a/src/__tests__/api-templates.test.ts
+++ b/src/__tests__/api-templates.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createTestDb, _setDb, migrate } from "@/lib/db";
+import type { Client } from "@libsql/client";
+import { GET as templatesGET, POST as templatesPOST } from "@/app/api/templates/route";
+import { POST as keysPOST } from "@/app/api/keys/route";
+import { NextRequest } from "next/server";
+
+let db: Client;
+let restore: () => void;
+
+async function getApiKey(agentId: string): Promise<string> {
+  const req = new NextRequest("http://localhost:3000/api/keys", {
+    method: "POST",
+    body: JSON.stringify({ agent_id: agentId }),
+    headers: { "Content-Type": "application/json" },
+  });
+  const res = await keysPOST(req);
+  const data = await res.json();
+  return data.api_key;
+}
+
+beforeEach(async () => {
+  db = createTestDb();
+  restore = _setDb(db);
+  await migrate(db);
+});
+
+afterEach(() => {
+  restore();
+});
+
+describe("GET /api/templates", () => {
+  it("returns built-in templates", async () => {
+    const req = new NextRequest("http://localhost:3000/api/templates");
+    const res = await templatesGET(req);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.templates.length).toBeGreaterThanOrEqual(6);
+    expect(data.templates.every((t: { built_in: boolean }) => t.built_in === true)).toBe(true);
+  });
+
+  it("includes agent-to-agent collaboration template", async () => {
+    const req = new NextRequest("http://localhost:3000/api/templates?category=agent-services");
+    const res = await templatesGET(req);
+    const data = await res.json();
+    expect(data.templates.length).toBe(1);
+    expect(data.templates[0].name).toBe("Agent-to-Agent Collaboration");
+  });
+
+  it("filters by category", async () => {
+    const req = new NextRequest("http://localhost:3000/api/templates?category=consulting");
+    const res = await templatesGET(req);
+    const data = await res.json();
+    expect(data.templates.length).toBeGreaterThanOrEqual(1);
+    expect(data.templates.every((t: { category: string }) => t.category === "consulting")).toBe(true);
+  });
+
+  it("returns empty for unknown category", async () => {
+    const req = new NextRequest("http://localhost:3000/api/templates?category=nonexistent");
+    const res = await templatesGET(req);
+    const data = await res.json();
+    expect(data.templates.length).toBe(0);
+  });
+
+  it("includes custom templates when agent_id provided", async () => {
+    const key = await getApiKey("alice");
+
+    const createReq = new NextRequest("http://localhost:3000/api/templates", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "My Custom Template",
+        category: "freelance-dev",
+        side: "offering",
+        description: "Custom dev template",
+        suggested_params: { skills: ["rust"] },
+        suggested_terms: { type: "project", rate: 100 },
+      }),
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${key}`,
+      },
+    });
+    await templatesPOST(createReq);
+
+    const req = new NextRequest("http://localhost:3000/api/templates?agent_id=alice");
+    const res = await templatesGET(req);
+    const data = await res.json();
+
+    const custom = data.templates.filter((t: { built_in: boolean }) => !t.built_in);
+    expect(custom.length).toBe(1);
+    expect(custom[0].name).toBe("My Custom Template");
+    expect(custom[0].suggested_params.skills).toEqual(["rust"]);
+  });
+});
+
+describe("POST /api/templates", () => {
+  it("creates a custom template", async () => {
+    const key = await getApiKey("alice");
+    const req = new NextRequest("http://localhost:3000/api/templates", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "Security Audit",
+        category: "security",
+        side: "offering",
+        description: "Comprehensive security review",
+        suggested_params: { skills: ["security", "pentesting"] },
+        suggested_terms: { type: "project", typical_rate_range: { min: 2000, max: 10000 } },
+      }),
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${key}`,
+      },
+    });
+    const res = await templatesPOST(req);
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.template_id).toMatch(/^tpl_/);
+  });
+
+  it("requires authentication", async () => {
+    const req = new NextRequest("http://localhost:3000/api/templates", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "Test",
+        category: "test",
+        side: "offering",
+      }),
+      headers: { "Content-Type": "application/json" },
+    });
+    const res = await templatesPOST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("validates required fields", async () => {
+    const key = await getApiKey("bob");
+    const req = new NextRequest("http://localhost:3000/api/templates", {
+      method: "POST",
+      body: JSON.stringify({ category: "test", side: "offering" }),
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${key}`,
+      },
+    });
+    const res = await templatesPOST(req);
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toContain("name");
+  });
+
+  it("validates side field", async () => {
+    const key = await getApiKey("charlie");
+    const req = new NextRequest("http://localhost:3000/api/templates", {
+      method: "POST",
+      body: JSON.stringify({ name: "Test", category: "test", side: "invalid" }),
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${key}`,
+      },
+    });
+    const res = await templatesPOST(req);
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toContain("side");
+  });
+});

--- a/src/app/api/templates/route.ts
+++ b/src/app/api/templates/route.ts
@@ -1,0 +1,238 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import { authenticateRequest } from "@/lib/auth";
+import { checkRateLimit, RATE_LIMITS } from "@/lib/rate-limit";
+
+/**
+ * Deal Templates - pre-defined collaboration patterns that agents can use
+ * to quickly create profiles or propose standard deal structures.
+ *
+ * Built-in templates are returned by default. Agents can also create custom ones.
+ */
+
+const BUILT_IN_TEMPLATES = [
+  {
+    id: "tpl_code_review",
+    name: "Code Review",
+    category: "freelance-dev",
+    description: "One-time or recurring code review engagement",
+    side: "offering" as const,
+    suggested_params: {
+      skills: ["code-review"],
+      hours_min: 2,
+      hours_max: 10,
+      duration_min_weeks: 1,
+      duration_max_weeks: 4,
+      remote: "remote",
+    },
+    suggested_terms: {
+      type: "hourly",
+      typical_rate_range: { min: 50, max: 150, currency: "EUR" },
+      typical_duration: "1-4 weeks",
+    },
+    built_in: true,
+  },
+  {
+    id: "tpl_pair_programming",
+    name: "Pair Programming Session",
+    category: "freelance-dev",
+    description: "Collaborative coding session for problem-solving or knowledge transfer",
+    side: "offering" as const,
+    suggested_params: {
+      skills: ["pair-programming"],
+      hours_min: 1,
+      hours_max: 4,
+      duration_min_weeks: 1,
+      duration_max_weeks: 1,
+      remote: "remote",
+    },
+    suggested_terms: {
+      type: "session",
+      typical_rate_range: { min: 80, max: 200, currency: "EUR" },
+      typical_duration: "1-4 hours",
+    },
+    built_in: true,
+  },
+  {
+    id: "tpl_consulting",
+    name: "Technical Consulting",
+    category: "consulting",
+    description: "Architecture review, tech strategy, or advisory engagement",
+    side: "offering" as const,
+    suggested_params: {
+      skills: ["architecture", "strategy"],
+      hours_min: 5,
+      hours_max: 20,
+      duration_min_weeks: 2,
+      duration_max_weeks: 12,
+      remote: "remote",
+    },
+    suggested_terms: {
+      type: "hourly",
+      typical_rate_range: { min: 100, max: 250, currency: "EUR" },
+      typical_duration: "2-12 weeks",
+    },
+    built_in: true,
+  },
+  {
+    id: "tpl_content_writing",
+    name: "Content Writing",
+    category: "content",
+    description: "Blog posts, documentation, technical writing",
+    side: "offering" as const,
+    suggested_params: {
+      skills: ["writing", "technical-writing"],
+      hours_min: 5,
+      hours_max: 20,
+      duration_min_weeks: 1,
+      duration_max_weeks: 8,
+      remote: "remote",
+    },
+    suggested_terms: {
+      type: "per-piece",
+      typical_rate_range: { min: 200, max: 1000, currency: "EUR" },
+      typical_duration: "1-2 weeks per piece",
+    },
+    built_in: true,
+  },
+  {
+    id: "tpl_data_task",
+    name: "Data Processing Task",
+    category: "data",
+    description: "Data extraction, transformation, analysis, or pipeline setup",
+    side: "offering" as const,
+    suggested_params: {
+      skills: ["data-processing", "ETL"],
+      hours_min: 10,
+      hours_max: 40,
+      duration_min_weeks: 1,
+      duration_max_weeks: 4,
+      remote: "remote",
+    },
+    suggested_terms: {
+      type: "project",
+      typical_rate_range: { min: 500, max: 5000, currency: "EUR" },
+      typical_duration: "1-4 weeks",
+    },
+    built_in: true,
+  },
+  {
+    id: "tpl_agent_collab",
+    name: "Agent-to-Agent Collaboration",
+    category: "agent-services",
+    description: "AI agents offering services to other AI agents (research, automation, monitoring)",
+    side: "offering" as const,
+    suggested_params: {
+      skills: ["automation", "research", "monitoring"],
+      remote: "remote",
+    },
+    suggested_terms: {
+      type: "per-task",
+      typical_rate_range: { min: 1, max: 50, currency: "EUR" },
+      typical_duration: "per task",
+    },
+    built_in: true,
+  },
+];
+
+/** GET /api/templates - List available deal templates */
+export async function GET(req: NextRequest) {
+  const rateLimited = checkRateLimit(req, RATE_LIMITS.READ.limit, RATE_LIMITS.READ.windowMs, RATE_LIMITS.READ.prefix);
+  if (rateLimited) return rateLimited;
+
+  const { searchParams } = new URL(req.url);
+  const category = searchParams.get("category");
+  const agentId = searchParams.get("agent_id");
+
+  // Start with built-in templates
+  let templates = [...BUILT_IN_TEMPLATES];
+
+  // Filter by category if specified
+  if (category) {
+    templates = templates.filter(t => t.category === category);
+  }
+
+  // Fetch custom templates if agent_id provided
+  if (agentId) {
+    const db = getDb();
+    const result = await db.execute({
+      sql: `SELECT id, name, category, description, side, suggested_params, suggested_terms, created_at
+            FROM deal_templates WHERE agent_id = ? ${category ? "AND category = ?" : ""}
+            ORDER BY created_at DESC`,
+      args: category ? [agentId, category] : [agentId],
+    });
+
+    const customTemplates = result.rows.map(row => ({
+      id: row.id as string,
+      name: row.name as string,
+      category: row.category as string,
+      description: row.description as string | null,
+      side: row.side as string,
+      suggested_params: JSON.parse(row.suggested_params as string),
+      suggested_terms: JSON.parse(row.suggested_terms as string),
+      built_in: false,
+      created_at: row.created_at as string,
+    }));
+
+    templates = [...templates, ...customTemplates];
+  }
+
+  return NextResponse.json({ templates });
+}
+
+/** POST /api/templates - Create a custom deal template (auth required) */
+export async function POST(req: NextRequest) {
+  const rateLimited = checkRateLimit(req, RATE_LIMITS.WRITE.limit, RATE_LIMITS.WRITE.windowMs, RATE_LIMITS.WRITE.prefix);
+  if (rateLimited) return rateLimited;
+
+  const auth = await authenticateRequest(req);
+  if (!auth) {
+    return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+  }
+
+  let body: {
+    name?: string;
+    category?: string;
+    description?: string;
+    side?: string;
+    suggested_params?: Record<string, unknown>;
+    suggested_terms?: Record<string, unknown>;
+  };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const { name, category, description, side, suggested_params, suggested_terms } = body;
+
+  if (!name || typeof name !== "string" || name.trim().length === 0) {
+    return NextResponse.json({ error: "name is required" }, { status: 400 });
+  }
+  if (!category || typeof category !== "string" || category.trim().length === 0) {
+    return NextResponse.json({ error: "category is required" }, { status: 400 });
+  }
+  if (!side || !["offering", "seeking"].includes(side)) {
+    return NextResponse.json({ error: "side must be 'offering' or 'seeking'" }, { status: 400 });
+  }
+
+  const db = getDb();
+  const id = `tpl_${crypto.randomUUID().slice(0, 8)}`;
+
+  await db.execute({
+    sql: `INSERT INTO deal_templates (id, agent_id, name, category, description, side, suggested_params, suggested_terms)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    args: [
+      id,
+      auth.agent_id,
+      name.trim(),
+      category.trim(),
+      description?.trim() || null,
+      side,
+      JSON.stringify(suggested_params || {}),
+      JSON.stringify(suggested_terms || {}),
+    ],
+  });
+
+  return NextResponse.json({ template_id: id }, { status: 201 });
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -82,6 +82,21 @@ export async function migrate(db: Client): Promise<void> {
   } catch {
     // Column already exists – ignore
   }
+
+  // Deal templates table
+  await db.executeMultiple(`
+    CREATE TABLE IF NOT EXISTS deal_templates (
+      id TEXT PRIMARY KEY,
+      agent_id TEXT NOT NULL,
+      name TEXT NOT NULL,
+      category TEXT NOT NULL,
+      description TEXT,
+      side TEXT NOT NULL CHECK (side IN ('offering', 'seeking')),
+      suggested_params TEXT NOT NULL DEFAULT '{}',
+      suggested_terms TEXT NOT NULL DEFAULT '{}',
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `);
 }
 
 /** Initialize the default singleton DB with migrations. */


### PR DESCRIPTION
## Summary
Implements deal templates (issue #16) - pre-defined collaboration patterns that help agents quickly create profiles.

## Changes
- `GET /api/templates` - List built-in + custom templates, filter by category
- `POST /api/templates` - Create custom templates (auth required)
- 6 built-in templates: Code Review, Pair Programming, Technical Consulting, Content Writing, Data Processing, Agent-to-Agent Collaboration
- DB migration adds `deal_templates` table
- 9 new tests

## API Examples
```
GET /api/templates                          # All templates
GET /api/templates?category=consulting      # Filter by category
GET /api/templates?agent_id=xxx             # Include agent's custom templates
POST /api/templates (auth required)         # Create custom template
```

Closes #16