### PR TITLE
fix: add ensureDb() for auto-migration on Vercel

### DIFF
--- a/src/app/api/activity/route.ts
+++ b/src/app/api/activity/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getDb } from "@/lib/db";
+import { ensureDb } from "@/lib/db";
 import { authenticateRequest } from "@/lib/auth";
 import { checkRateLimit, RATE_LIMITS } from "@/lib/rate-limit";
 
@@ -49,7 +49,7 @@ export async function GET(req: NextRequest) {
 
   const since = searchParams.get("since");
 
-  const db = getDb();
+  const db = await ensureDb();
 
   const profilesResult = await db.execute({
     sql: "SELECT id FROM profiles WHERE agent_id = ?",

--- a/src/app/api/agents/[agentId]/summary/route.ts
+++ b/src/app/api/agents/[agentId]/summary/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getDb } from "@/lib/db";
+import { ensureDb } from "@/lib/db";
 import { checkRateLimit, RATE_LIMITS } from "@/lib/rate-limit";
 
 /**
@@ -19,7 +19,7 @@ export async function GET(
     return NextResponse.json({ error: "agentId is required" }, { status: 400 });
   }
 
-  const db = getDb();
+  const db = await ensureDb();
 
   // Active profiles
   const profilesResult = await db.execute({

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getDb } from "@/lib/db";
+import { ensureDb } from "@/lib/db";
 
 /**
  * GET /api/categories - Discover active categories with profile counts
@@ -8,7 +8,7 @@ import { getDb } from "@/lib/db";
  * Returns categories with offering/seeking counts and recent deal activity.
  */
 export async function GET() {
-  const db = getDb();
+  const db = await ensureDb();
 
   const categoriesResult = await db.execute(
     `SELECT 

--- a/src/app/api/connect/[agentId]/route.ts
+++ b/src/app/api/connect/[agentId]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getDb } from "@/lib/db";
+import { ensureDb } from "@/lib/db";
 import type { Profile, ProfileParams } from "@/lib/types";
 
 /**
@@ -15,7 +15,7 @@ export async function GET(
     return NextResponse.json({ error: "agentId is required" }, { status: 400 });
   }
 
-  const db = getDb();
+  const db = await ensureDb();
   const result = await db.execute({
     sql: "SELECT * FROM profiles WHERE agent_id = ? AND active = 1 ORDER BY created_at DESC",
     args: [agentId],

--- a/src/app/api/connect/route.ts
+++ b/src/app/api/connect/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getDb } from "@/lib/db";
+import { ensureDb } from "@/lib/db";
 import { authenticateRequest } from "@/lib/auth";
 import { checkRateLimit, RATE_LIMITS } from "@/lib/rate-limit";
 import type { ConnectRequest, Side } from "@/lib/types";
@@ -55,7 +55,7 @@ export async function POST(req: NextRequest) {
   if (data.agent_id !== auth.agent_id) {
     return NextResponse.json({ error: "agent_id does not match authenticated key" }, { status: 403 });
   }
-  const db = getDb();
+  const db = await ensureDb();
 
   // Deactivate previous profiles from the same agent with the same side+category
   const existingResult = await db.execute({
@@ -101,7 +101,7 @@ export async function DELETE(req: NextRequest) {
     return NextResponse.json({ error: "Provide profile_id or agent_id query parameter" }, { status: 400 });
   }
 
-  const db = getDb();
+  const db = await ensureDb();
 
   if (profileId) {
     const profileResult = await db.execute({

--- a/src/app/api/deals/[matchId]/approve/route.ts
+++ b/src/app/api/deals/[matchId]/approve/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getDb } from "@/lib/db";
+import { ensureDb } from "@/lib/db";
 import { authenticateRequest } from "@/lib/auth";
 import { checkRateLimit, RATE_LIMITS } from "@/lib/rate-limit";
 import type { Match, Profile, Approval } from "@/lib/types";
@@ -41,7 +41,7 @@ export async function POST(
     return NextResponse.json({ error: "approved must be a boolean" }, { status: 400 });
   }
 
-  const db = getDb();
+  const db = await ensureDb();
   const matchResult = await db.execute({
     sql: "SELECT * FROM matches WHERE id = ?",
     args: [matchId],

--- a/src/app/api/deals/[matchId]/messages/route.ts
+++ b/src/app/api/deals/[matchId]/messages/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getDb } from "@/lib/db";
+import { ensureDb } from "@/lib/db";
 import { authenticateRequest } from "@/lib/auth";
 import { checkRateLimit, RATE_LIMITS } from "@/lib/rate-limit";
 import type { Match, Profile, SendMessageRequest } from "@/lib/types";
@@ -57,7 +57,7 @@ export async function POST(
     proposed_terms: b.proposed_terms as Record<string, unknown> | undefined,
   };
 
-  const db = getDb();
+  const db = await ensureDb();
   const matchResult = await db.execute({
     sql: "SELECT * FROM matches WHERE id = ?",
     args: [matchId],

--- a/src/app/api/deals/[matchId]/route.ts
+++ b/src/app/api/deals/[matchId]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getDb } from "@/lib/db";
+import { ensureDb } from "@/lib/db";
 import type { Match, Message, Approval, Profile } from "@/lib/types";
 
 export async function GET(
@@ -8,7 +8,7 @@ export async function GET(
 ) {
   const { matchId } = await params;
 
-  const db = getDb();
+  const db = await ensureDb();
   const matchResult = await db.execute({
     sql: "SELECT * FROM matches WHERE id = ?",
     args: [matchId],

--- a/src/app/api/deals/route.ts
+++ b/src/app/api/deals/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getDb } from "@/lib/db";
+import { ensureDb } from "@/lib/db";
 
 interface DealRow {
   id: string;
@@ -18,7 +18,7 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "agent_id query parameter is required" }, { status: 400 });
   }
 
-  const db = getDb();
+  const db = await ensureDb();
 
   // Find all profile ids for this agent
   const profilesResult = await db.execute({

--- a/src/app/api/keys/route.ts
+++ b/src/app/api/keys/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getDb } from "@/lib/db";
+import { ensureDb } from "@/lib/db";
 import { generateApiKey } from "@/lib/auth";
 import { checkRateLimit, RATE_LIMITS } from "@/lib/rate-limit";
 
@@ -27,7 +27,7 @@ export async function POST(req: NextRequest) {
   const { raw, hash } = generateApiKey();
   const id = crypto.randomUUID();
 
-  const db = getDb();
+  const db = await ensureDb();
   await db.execute({
     sql: "INSERT INTO api_keys (id, agent_id, key_hash) VALUES (?, ?, ?)",
     args: [id, agentId, hash],

--- a/src/app/api/matches/[profileId]/route.ts
+++ b/src/app/api/matches/[profileId]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { findMatches } from "@/lib/matching";
-import { getDb } from "@/lib/db";
+import { ensureDb } from "@/lib/db";
 import type { Profile, ProfileParams } from "@/lib/types";
 
 export async function GET(
@@ -13,7 +13,7 @@ export async function GET(
     return NextResponse.json({ error: "profileId is required" }, { status: 400 });
   }
 
-  const db = getDb();
+  const db = await ensureDb();
   const profileResult = await db.execute({
     sql: "SELECT * FROM profiles WHERE id = ? AND active = 1",
     args: [profileId],

--- a/src/app/api/matches/batch/route.ts
+++ b/src/app/api/matches/batch/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { authenticateRequest } from "@/lib/auth";
 import { findMatches } from "@/lib/matching";
-import { getDb } from "@/lib/db";
+import { ensureDb } from "@/lib/db";
 import type { Profile, ProfileParams } from "@/lib/types";
 
 export async function GET(req: NextRequest) {
@@ -22,7 +22,7 @@ export async function GET(req: NextRequest) {
   }
 
   // Get all active profiles for this agent
-  const db = getDb();
+  const db = await ensureDb();
   const profilesResult = await db.execute({
     sql: "SELECT * FROM profiles WHERE agent_id = ? AND active = 1",
     args: [agentId],

--- a/src/app/api/profiles/[profileId]/route.ts
+++ b/src/app/api/profiles/[profileId]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getDb } from "@/lib/db";
+import { ensureDb } from "@/lib/db";
 import { authenticateRequest } from "@/lib/auth";
 import { checkRateLimit, RATE_LIMITS } from "@/lib/rate-limit";
 import type { Profile, ProfileParams } from "@/lib/types";
@@ -13,7 +13,7 @@ export async function GET(
   { params }: { params: Promise<{ profileId: string }> }
 ) {
   const { profileId } = await params;
-  const db = getDb();
+  const db = await ensureDb();
 
   const result = await db.execute({
     sql: "SELECT * FROM profiles WHERE id = ?",
@@ -73,7 +73,7 @@ export async function PATCH(
     return NextResponse.json({ error: "agent_id does not match authenticated key" }, { status: 403 });
   }
 
-  const db = getDb();
+  const db = await ensureDb();
   const profileResult = await db.execute({
     sql: "SELECT * FROM profiles WHERE id = ? AND active = 1",
     args: [profileId],

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getDb } from "@/lib/db";
+import { ensureDb } from "@/lib/db";
 import type { Profile, ProfileParams } from "@/lib/types";
 
 /**
@@ -19,7 +19,7 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "side must be 'offering' or 'seeking'" }, { status: 400 });
   }
 
-  const db = getDb();
+  const db = await ensureDb();
 
   // Build query dynamically
   const conditions: string[] = ["active = 1"];

--- a/src/app/api/stats/route.ts
+++ b/src/app/api/stats/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from "next/server";
-import { getDb } from "@/lib/db";
+import { ensureDb } from "@/lib/db";
 
 /**
  * GET /api/stats - Platform statistics and health check
  */
 export async function GET() {
-  const db = getDb();
+  const db = await ensureDb();
 
   const profileStatsResult = await db.execute(`
     SELECT 

--- a/src/app/api/templates/route.ts
+++ b/src/app/api/templates/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getDb } from "@/lib/db";
+import { ensureDb } from "@/lib/db";
 import { authenticateRequest } from "@/lib/auth";
 import { checkRateLimit, RATE_LIMITS } from "@/lib/rate-limit";
 
@@ -154,7 +154,7 @@ export async function GET(req: NextRequest) {
 
   // Fetch custom templates if agent_id provided
   if (agentId) {
-    const db = getDb();
+    const db = await ensureDb();
     const result = await db.execute({
       sql: `SELECT id, name, category, description, side, suggested_params, suggested_terms, created_at
             FROM deal_templates WHERE agent_id = ? ${category ? "AND category = ?" : ""}
@@ -216,7 +216,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "side must be 'offering' or 'seeking'" }, { status: 400 });
   }
 
-  const db = getDb();
+  const db = await ensureDb();
   const id = `tpl_${crypto.randomUUID().slice(0, 8)}`;
 
   await db.execute({

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes } from "crypto";
-import { getDb } from "@/lib/db";
+import { ensureDb } from "@/lib/db";
 import type { NextRequest } from "next/server";
 
 const KEY_PREFIX = "lc_";
@@ -29,7 +29,7 @@ export async function authenticateRequest(req: NextRequest): Promise<AuthResult 
   const rawKey = match[1];
   const keyHash = hashApiKey(rawKey);
 
-  const db = getDb();
+  const db = await ensureDb();
   const result = await db.execute({
     sql: "SELECT id, agent_id FROM api_keys WHERE key_hash = ?",
     args: [keyHash],

--- a/src/lib/cleanup.ts
+++ b/src/lib/cleanup.ts
@@ -1,11 +1,11 @@
-import { getDb } from "./db";
+import { ensureDb } from "./db";
 
 /**
  * Expire matches whose expires_at has passed and are still in an active state.
  * Returns the number of deals marked as expired.
  */
 export async function cleanupExpiredDeals(): Promise<number> {
-  const db = getDb();
+  const db = await ensureDb();
   const result = await db.execute(
     `UPDATE matches
      SET status = 'expired'
@@ -22,7 +22,7 @@ export async function cleanupExpiredDeals(): Promise<number> {
  * Returns the number of profiles deactivated.
  */
 export async function cleanupInactiveProfiles(daysInactive: number): Promise<number> {
-  const db = getDb();
+  const db = await ensureDb();
   const cutoff = new Date(Date.now() - daysInactive * 24 * 60 * 60 * 1000)
     .toISOString()
     .replace("T", " ")

--- a/src/lib/matching.ts
+++ b/src/lib/matching.ts
@@ -1,8 +1,8 @@
-import { getDb } from "./db";
+import { ensureDb } from "./db";
 import type { Profile, ProfileParams, OverlapSummary } from "./types";
 
 export async function findMatches(profileId: string): Promise<Array<{ matchId: string; counterpart: Profile; overlap: OverlapSummary }>> {
-  const db = getDb();
+  const db = await ensureDb();
   const profileResult = await db.execute({
     sql: "SELECT * FROM profiles WHERE id = ? AND active = 1",
     args: [profileId],


### PR DESCRIPTION
## Problem
The Vercel deployment returns 500 on all API endpoints because the database is never initialized. The `migrate()` function exists but is never called in production routes - only in tests.

Additionally, on Vercel's serverless environment, the default DB path `file:data/negotiate.db` is not writable.

## Solution
1. Add `ensureDb()` - a wrapper around `getDb()` that runs migrations on first call (idempotent)
2. Use `file:/tmp/negotiate.db` on Vercel (ephemeral but functional until Turso is set up)
3. Replace all `getDb()` calls in API routes and lib files with `await ensureDb()`

## Notes
- Data on Vercel is ephemeral (/tmp clears on cold starts) - this is a stopgap until Turso credentials are configured
- All 110 tests pass
- No behavioral changes for non-Vercel environments (still uses `file:data/negotiate.db`)