### PR TITLE
fix: TypeScript build errors in activity feed and templates

### DIFF
--- a/src/app/api/activity/route.ts
+++ b/src/app/api/activity/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import type { InValue } from "@libsql/client";
 import { ensureDb } from "@/lib/db";
 import { authenticateRequest } from "@/lib/auth";
 import { checkRateLimit, RATE_LIMITS } from "@/lib/rate-limit";
@@ -75,7 +76,7 @@ export async function GET(req: NextRequest) {
       JOIN profiles pa ON pa.id = m.profile_a_id
       JOIN profiles pb ON pb.id = m.profile_b_id
       WHERE (m.profile_a_id IN (${placeholders}) OR m.profile_b_id IN (${placeholders}))`;
-    const args: unknown[] = [...profileIds, ...profileIds];
+    const args: InValue[] = [...profileIds, ...profileIds];
 
     if (since) {
       sql += " AND m.created_at > ?";
@@ -111,7 +112,7 @@ export async function GET(req: NextRequest) {
       JOIN matches m ON m.id = msg.match_id
       WHERE msg.sender_agent_id != ?
       AND (m.profile_a_id IN (${placeholders}) OR m.profile_b_id IN (${placeholders}))`;
-    const args: unknown[] = [agentId, ...profileIds, ...profileIds];
+    const args: InValue[] = [agentId, ...profileIds, ...profileIds];
 
     if (since) {
       sql += " AND msg.created_at > ?";
@@ -146,7 +147,7 @@ export async function GET(req: NextRequest) {
       JOIN matches m ON m.id = a.match_id
       WHERE a.agent_id != ?
       AND (m.profile_a_id IN (${placeholders}) OR m.profile_b_id IN (${placeholders}))`;
-    const args: unknown[] = [agentId, ...profileIds, ...profileIds];
+    const args: InValue[] = [agentId, ...profileIds, ...profileIds];
 
     if (since) {
       sql += " AND a.created_at > ?";
@@ -175,7 +176,7 @@ export async function GET(req: NextRequest) {
       FROM matches m
       WHERE m.status = 'expired'
       AND (m.profile_a_id IN (${placeholders}) OR m.profile_b_id IN (${placeholders}))`;
-    const args: unknown[] = [...profileIds, ...profileIds];
+    const args: InValue[] = [...profileIds, ...profileIds];
 
     if (since) {
       sql += " AND m.expires_at > ?";

--- a/src/app/api/templates/route.ts
+++ b/src/app/api/templates/route.ts
@@ -145,7 +145,8 @@ export async function GET(req: NextRequest) {
   const agentId = searchParams.get("agent_id");
 
   // Start with built-in templates
-  let templates = [...BUILT_IN_TEMPLATES];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let templates: any[] = [...BUILT_IN_TEMPLATES];
 
   // Filter by category if specified
   if (category) {


### PR DESCRIPTION
Follow-up to #33. Fixes two TypeScript strict mode errors that prevented the Next.js build:
1. `unknown[]` args in activity feed route -> `InValue[]` from libsql
2. Template array type mismatch when combining built-in and custom templates