### PR TITLE
feat: add agent reputation system (#13)

### DIFF
--- a/src/__tests__/api-reputation.test.ts
+++ b/src/__tests__/api-reputation.test.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createTestDb, _setDb, migrate } from "@/lib/db";
+import type { Client } from "@libsql/client";
+import { POST as connectPOST } from "@/app/api/connect/route";
+import { POST as keysPOST } from "@/app/api/keys/route";
+import { GET as matchesGET } from "@/app/api/matches/[profileId]/route";
+import { POST as messagesPOST } from "@/app/api/deals/[matchId]/messages/route";
+import { POST as approvePOST } from "@/app/api/deals/[matchId]/approve/route";
+import { GET as reputationGET } from "@/app/api/reputation/[agentId]/route";
+import { POST as reviewPOST } from "@/app/api/reputation/[agentId]/review/route";
+import { GET as summaryGET } from "@/app/api/agents/[agentId]/summary/route";
+import { NextRequest } from "next/server";
+
+let db: Client;
+let restore: () => void;
+let aliceKey: string;
+let bobKey: string;
+
+async function getApiKey(agentId: string): Promise<string> {
+  const req = new NextRequest("http://localhost:3000/api/keys", {
+    method: "POST",
+    body: JSON.stringify({ agent_id: agentId }),
+    headers: { "Content-Type": "application/json" },
+  });
+  const res = await keysPOST(req);
+  const data = await res.json();
+  return data.api_key;
+}
+
+beforeEach(async () => {
+  db = createTestDb();
+  restore = _setDb(db);
+  await migrate(db);
+  aliceKey = await getApiKey("alice");
+  bobKey = await getApiKey("bob");
+});
+
+afterEach(() => {
+  restore();
+});
+
+function jsonReq(url: string, body?: unknown, apiKey?: string): NextRequest {
+  const headers: Record<string, string> = {};
+  if (body) headers["Content-Type"] = "application/json";
+  if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
+  return new NextRequest(`http://localhost:3000${url}`, {
+    method: body ? "POST" : "GET",
+    ...(body ? { body: JSON.stringify(body) } : {}),
+    headers,
+  });
+}
+
+/** Create two profiles, match them, propose, and approve from both sides. */
+async function createApprovedDeal(): Promise<{ offeringId: string; seekingId: string; matchId: string }> {
+  const r1 = await connectPOST(jsonReq("/api/connect", {
+    agent_id: "alice", side: "offering", category: "dev",
+    params: { skills: ["react", "ts"], rate_min: 50, rate_max: 70 },
+  }, aliceKey));
+  const { profile_id: offeringId } = await r1.json();
+
+  const r2 = await connectPOST(jsonReq("/api/connect", {
+    agent_id: "bob", side: "seeking", category: "dev",
+    params: { skills: ["react"], rate_min: 40, rate_max: 60 },
+  }, bobKey));
+  const { profile_id: seekingId } = await r2.json();
+
+  const matchRes = await matchesGET(
+    jsonReq(`/api/matches/${offeringId}`),
+    { params: Promise.resolve({ profileId: offeringId }) }
+  );
+  const { matches } = await matchRes.json();
+  const matchId = matches[0].match_id;
+
+  // Proposal (moves to 'proposed')
+  await messagesPOST(
+    jsonReq(`/api/deals/${matchId}/messages`, {
+      agent_id: "alice", content: "Offer terms", message_type: "proposal",
+      proposed_terms: { rate: 55 },
+    }, aliceKey),
+    { params: Promise.resolve({ matchId }) }
+  );
+
+  // Both approve
+  await approvePOST(
+    jsonReq(`/api/deals/${matchId}/approve`, { agent_id: "alice", approved: true }, aliceKey),
+    { params: Promise.resolve({ matchId }) }
+  );
+  await approvePOST(
+    jsonReq(`/api/deals/${matchId}/approve`, { agent_id: "bob", approved: true }, bobKey),
+    { params: Promise.resolve({ matchId }) }
+  );
+
+  return { offeringId, seekingId, matchId };
+}
+
+// ─── POST /api/reputation/:agentId/review ───────────────────────────
+
+describe("POST /api/reputation/:agentId/review", () => {
+  it("submits a review for an approved deal", async () => {
+    const { matchId } = await createApprovedDeal();
+
+    const res = await reviewPOST(
+      jsonReq("/api/reputation/bob/review", { match_id: matchId, rating: 5, comment: "Great agent!" }, aliceKey),
+      { params: Promise.resolve({ agentId: "bob" }) }
+    );
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.rating).toBe(5);
+    expect(data.reviewer_agent_id).toBe("alice");
+    expect(data.reviewed_agent_id).toBe("bob");
+    expect(data.comment).toBe("Great agent!");
+    expect(data.id).toBeTruthy();
+  });
+
+  it("allows review without comment", async () => {
+    const { matchId } = await createApprovedDeal();
+
+    const res = await reviewPOST(
+      jsonReq("/api/reputation/bob/review", { match_id: matchId, rating: 3 }, aliceKey),
+      { params: Promise.resolve({ agentId: "bob" }) }
+    );
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.comment).toBeNull();
+  });
+
+  it("blocks duplicate reviews", async () => {
+    const { matchId } = await createApprovedDeal();
+
+    await reviewPOST(
+      jsonReq("/api/reputation/bob/review", { match_id: matchId, rating: 5 }, aliceKey),
+      { params: Promise.resolve({ agentId: "bob" }) }
+    );
+    const res = await reviewPOST(
+      jsonReq("/api/reputation/bob/review", { match_id: matchId, rating: 3 }, aliceKey),
+      { params: Promise.resolve({ agentId: "bob" }) }
+    );
+    expect(res.status).toBe(409);
+  });
+
+  it("blocks unauthorized requests", async () => {
+    const { matchId } = await createApprovedDeal();
+
+    const res = await reviewPOST(
+      jsonReq("/api/reputation/bob/review", { match_id: matchId, rating: 5 }),
+      { params: Promise.resolve({ agentId: "bob" }) }
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("only allows reviews for approved deals", async () => {
+    // Create match but don't approve
+    const r1 = await connectPOST(jsonReq("/api/connect", {
+      agent_id: "alice", side: "offering", category: "design",
+      params: { skills: ["figma"], rate_min: 30, rate_max: 50 },
+    }, aliceKey));
+    const { profile_id: offeringId } = await r1.json();
+
+    await connectPOST(jsonReq("/api/connect", {
+      agent_id: "bob", side: "seeking", category: "design",
+      params: { skills: ["figma"], rate_min: 20, rate_max: 40 },
+    }, bobKey));
+
+    const matchRes = await matchesGET(
+      jsonReq(`/api/matches/${offeringId}`),
+      { params: Promise.resolve({ profileId: offeringId }) }
+    );
+    const { matches } = await matchRes.json();
+    const matchId = matches[0].match_id;
+
+    const res = await reviewPOST(
+      jsonReq("/api/reputation/bob/review", { match_id: matchId, rating: 5 }, aliceKey),
+      { params: Promise.resolve({ agentId: "bob" }) }
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toContain("approved");
+  });
+
+  it("validates rating range", async () => {
+    const { matchId } = await createApprovedDeal();
+
+    for (const bad of [0, 6, 3.5, -1]) {
+      const res = await reviewPOST(
+        jsonReq("/api/reputation/bob/review", { match_id: matchId, rating: bad }, aliceKey),
+        { params: Promise.resolve({ agentId: "bob" }) }
+      );
+      expect(res.status).toBe(400);
+    }
+  });
+
+  it("prevents self-reviews", async () => {
+    const { matchId } = await createApprovedDeal();
+
+    const res = await reviewPOST(
+      jsonReq("/api/reputation/alice/review", { match_id: matchId, rating: 5 }, aliceKey),
+      { params: Promise.resolve({ agentId: "alice" }) }
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toContain("yourself");
+  });
+
+  it("blocks reviews from non-participants", async () => {
+    const { matchId } = await createApprovedDeal();
+    const charlieKey = await getApiKey("charlie");
+
+    const res = await reviewPOST(
+      jsonReq("/api/reputation/bob/review", { match_id: matchId, rating: 5 }, charlieKey),
+      { params: Promise.resolve({ agentId: "bob" }) }
+    );
+    expect(res.status).toBe(403);
+  });
+});
+
+// ─── GET /api/reputation/:agentId ───────────────────────────────────
+
+describe("GET /api/reputation/:agentId", () => {
+  it("returns empty reputation for agent with no reviews", async () => {
+    const res = await reputationGET(
+      jsonReq("/api/reputation/alice"),
+      { params: Promise.resolve({ agentId: "alice" }) }
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.agent_id).toBe("alice");
+    expect(data.avg_rating).toBe(0);
+    expect(data.total_reviews).toBe(0);
+    expect(data.rating_breakdown).toEqual({ 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 });
+    expect(data.recent_reviews).toEqual([]);
+  });
+
+  it("returns correct reputation after reviews", async () => {
+    const { matchId } = await createApprovedDeal();
+
+    await reviewPOST(
+      jsonReq("/api/reputation/bob/review", { match_id: matchId, rating: 4, comment: "Good" }, aliceKey),
+      { params: Promise.resolve({ agentId: "bob" }) }
+    );
+
+    const res = await reputationGET(
+      jsonReq("/api/reputation/bob"),
+      { params: Promise.resolve({ agentId: "bob" }) }
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.agent_id).toBe("bob");
+    expect(data.avg_rating).toBe(4);
+    expect(data.total_reviews).toBe(1);
+    expect(data.rating_breakdown[4]).toBe(1);
+    expect(data.recent_reviews).toHaveLength(1);
+    expect(data.recent_reviews[0].comment).toBe("Good");
+    expect(data.recent_reviews[0].reviewer_agent_id).toBe("alice");
+  });
+});
+
+// ─── Integration: reputation in summary ─────────────────────────────
+
+describe("GET /api/agents/:agentId/summary (reputation)", () => {
+  it("includes reputation in agent summary", async () => {
+    const { matchId } = await createApprovedDeal();
+
+    await reviewPOST(
+      jsonReq("/api/reputation/bob/review", { match_id: matchId, rating: 5 }, aliceKey),
+      { params: Promise.resolve({ agentId: "bob" }) }
+    );
+
+    const res = await summaryGET(
+      jsonReq("/api/agents/bob/summary"),
+      { params: Promise.resolve({ agentId: "bob" }) }
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.reputation).toBeDefined();
+    expect(data.reputation.avg_rating).toBe(5);
+    expect(data.reputation.total_reviews).toBe(1);
+  });
+});
+
+// ─── Integration: reputation in match results ───────────────────────
+
+describe("GET /api/matches/:profileId (counterpart reputation)", () => {
+  it("includes counterpart reputation in match results", async () => {
+    const { matchId } = await createApprovedDeal();
+
+    // Alice reviews Bob (rating 4)
+    await reviewPOST(
+      jsonReq("/api/reputation/bob/review", { match_id: matchId, rating: 4 }, aliceKey),
+      { params: Promise.resolve({ agentId: "bob" }) }
+    );
+
+    // New match where charlie sees bob as counterpart
+    const charlieKey = await getApiKey("charlie");
+    const r1 = await connectPOST(jsonReq("/api/connect", {
+      agent_id: "charlie", side: "offering", category: "qa",
+      params: { skills: ["testing"], rate_min: 30, rate_max: 50 },
+    }, charlieKey));
+    const { profile_id: charlieProfileId } = await r1.json();
+
+    await connectPOST(jsonReq("/api/connect", {
+      agent_id: "bob", side: "seeking", category: "qa",
+      params: { skills: ["testing"], rate_min: 20, rate_max: 40 },
+    }, bobKey));
+
+    const matchRes = await matchesGET(
+      jsonReq(`/api/matches/${charlieProfileId}`),
+      { params: Promise.resolve({ profileId: charlieProfileId }) }
+    );
+    const data = await matchRes.json();
+    expect(data.matches).toHaveLength(1);
+    expect(data.matches[0].counterpart_reputation).toBeDefined();
+    expect(data.matches[0].counterpart_reputation.avg_rating).toBe(4);
+    expect(data.matches[0].counterpart_reputation.total_reviews).toBe(1);
+  });
+});

--- a/src/app/api/reputation/[agentId]/review/route.ts
+++ b/src/app/api/reputation/[agentId]/review/route.ts
@@ -1,0 +1,109 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ensureDb } from "@/lib/db";
+import { authenticateRequest } from "@/lib/auth";
+import { checkRateLimit, RATE_LIMITS } from "@/lib/rate-limit";
+import { randomUUID } from "crypto";
+
+/**
+ * POST /api/reputation/:agentId/review
+ * Submit a review for an agent after a completed (approved) deal.
+ * Auth required – reviewer must be a participant in the deal.
+ */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ agentId: string }> }
+) {
+  const rateLimited = checkRateLimit(req, RATE_LIMITS.WRITE.limit, RATE_LIMITS.WRITE.windowMs, RATE_LIMITS.WRITE.prefix);
+  if (rateLimited) return rateLimited;
+
+  const auth = await authenticateRequest(req);
+  if (!auth) {
+    return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+  }
+
+  const { agentId } = await params;
+
+  if (!agentId || agentId.trim().length === 0) {
+    return NextResponse.json({ error: "agentId is required" }, { status: 400 });
+  }
+
+  if (auth.agent_id === agentId) {
+    return NextResponse.json({ error: "Cannot review yourself" }, { status: 400 });
+  }
+
+  let body: { match_id?: string; rating?: number; comment?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { match_id, rating, comment } = body;
+
+  if (!match_id || typeof match_id !== "string") {
+    return NextResponse.json({ error: "match_id is required" }, { status: 400 });
+  }
+  if (rating === undefined || typeof rating !== "number" || !Number.isInteger(rating) || rating < 1 || rating > 5) {
+    return NextResponse.json({ error: "rating must be an integer between 1 and 5" }, { status: 400 });
+  }
+  if (comment !== undefined && comment !== null && typeof comment !== "string") {
+    return NextResponse.json({ error: "comment must be a string" }, { status: 400 });
+  }
+
+  const db = await ensureDb();
+
+  // Check match exists and is approved
+  const matchResult = await db.execute({
+    sql: "SELECT id, profile_a_id, profile_b_id, status FROM matches WHERE id = ?",
+    args: [match_id],
+  });
+  const match = matchResult.rows[0] as unknown as {
+    id: string; profile_a_id: string; profile_b_id: string; status: string;
+  } | undefined;
+
+  if (!match) {
+    return NextResponse.json({ error: "Match not found" }, { status: 404 });
+  }
+  if (match.status !== "approved") {
+    return NextResponse.json({ error: "Reviews can only be submitted for approved deals" }, { status: 400 });
+  }
+
+  // Verify both reviewer and reviewed agent are participants
+  const participantsResult = await db.execute({
+    sql: `SELECT id, agent_id FROM profiles WHERE id IN (?, ?)`,
+    args: [match.profile_a_id, match.profile_b_id],
+  });
+  const participants = participantsResult.rows as unknown as Array<{ id: string; agent_id: string }>;
+
+  const reviewerIsParticipant = participants.some(p => p.agent_id === auth.agent_id);
+  const reviewedIsParticipant = participants.some(p => p.agent_id === agentId);
+
+  if (!reviewerIsParticipant || !reviewedIsParticipant) {
+    return NextResponse.json({ error: "Both reviewer and reviewed agent must be participants in this deal" }, { status: 403 });
+  }
+
+  // Check for duplicate
+  const existingResult = await db.execute({
+    sql: "SELECT id FROM reviews WHERE match_id = ? AND reviewer_agent_id = ?",
+    args: [match_id, auth.agent_id],
+  });
+  if (existingResult.rows.length > 0) {
+    return NextResponse.json({ error: "You have already submitted a review for this deal" }, { status: 409 });
+  }
+
+  const reviewId = randomUUID();
+  await db.execute({
+    sql: `INSERT INTO reviews (id, match_id, reviewer_agent_id, reviewed_agent_id, rating, comment)
+          VALUES (?, ?, ?, ?, ?, ?)`,
+    args: [reviewId, match_id, auth.agent_id, agentId, rating, comment ?? null],
+  });
+
+  return NextResponse.json({
+    id: reviewId,
+    match_id,
+    reviewer_agent_id: auth.agent_id,
+    reviewed_agent_id: agentId,
+    rating,
+    comment: comment ?? null,
+  }, { status: 201 });
+}

--- a/src/app/api/reputation/[agentId]/route.ts
+++ b/src/app/api/reputation/[agentId]/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ensureDb } from "@/lib/db";
+import { checkRateLimit, RATE_LIMITS } from "@/lib/rate-limit";
+
+/**
+ * GET /api/reputation/:agentId
+ * Public endpoint - returns agent reputation data.
+ */
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ agentId: string }> }
+) {
+  const rateLimited = checkRateLimit(req, RATE_LIMITS.READ.limit, RATE_LIMITS.READ.windowMs, RATE_LIMITS.READ.prefix);
+  if (rateLimited) return rateLimited;
+
+  const { agentId } = await params;
+
+  if (!agentId || agentId.trim().length === 0) {
+    return NextResponse.json({ error: "agentId is required" }, { status: 400 });
+  }
+
+  const db = await ensureDb();
+
+  // Aggregate stats
+  const statsResult = await db.execute({
+    sql: `SELECT
+            COUNT(*) as total_reviews,
+            COALESCE(AVG(rating * 1.0), 0) as avg_rating,
+            SUM(CASE WHEN rating = 1 THEN 1 ELSE 0 END) as r1,
+            SUM(CASE WHEN rating = 2 THEN 1 ELSE 0 END) as r2,
+            SUM(CASE WHEN rating = 3 THEN 1 ELSE 0 END) as r3,
+            SUM(CASE WHEN rating = 4 THEN 1 ELSE 0 END) as r4,
+            SUM(CASE WHEN rating = 5 THEN 1 ELSE 0 END) as r5
+          FROM reviews WHERE reviewed_agent_id = ?`,
+    args: [agentId],
+  });
+  const stats = statsResult.rows[0] as unknown as {
+    total_reviews: number; avg_rating: number;
+    r1: number; r2: number; r3: number; r4: number; r5: number;
+  };
+  const totalReviews = Number(stats.total_reviews);
+
+  // Recent reviews (last 10)
+  const recentResult = await db.execute({
+    sql: `SELECT id, match_id, reviewer_agent_id, rating, comment, created_at
+          FROM reviews WHERE reviewed_agent_id = ?
+          ORDER BY created_at DESC LIMIT 10`,
+    args: [agentId],
+  });
+  const recentReviews = recentResult.rows.map(r => ({
+    id: r.id as string,
+    match_id: r.match_id as string,
+    reviewer_agent_id: r.reviewer_agent_id as string,
+    rating: Number(r.rating),
+    comment: r.comment as string | null,
+    created_at: r.created_at as string,
+  }));
+
+  return NextResponse.json({
+    agent_id: agentId,
+    avg_rating: totalReviews > 0 ? Math.round(Number(stats.avg_rating) * 100) / 100 : 0,
+    total_reviews: totalReviews,
+    rating_breakdown: {
+      1: Number(stats.r1) || 0,
+      2: Number(stats.r2) || 0,
+      3: Number(stats.r3) || 0,
+      4: Number(stats.r4) || 0,
+      5: Number(stats.r5) || 0,
+    },
+    recent_reviews: recentReviews,
+  });
+}


### PR DESCRIPTION
## Agent Reputation System

Implements GitHub issue #13.

### New Endpoints
- **GET /api/reputation/:agentId** - Public endpoint returning agent reputation (avg_rating, total_reviews, rating_breakdown {1-5}, recent_reviews)
- **POST /api/reputation/:agentId/review** - Submit review after a completed deal (auth required)

### Validation & Constraints
- UNIQUE(match_id, reviewer_agent_id) - one review per agent per deal
- Only approved deals can be reviewed
- Reviewer must be a participant in the deal
- Cannot review yourself
- Rating must be integer 1-5

### Integrations
- `GET /api/agents/:agentId/summary` now includes `reputation` field
- `GET /api/matches/:profileId` now includes `counterpart_reputation` in each match

### Tests
- 12 new tests covering: submit review, get reputation, duplicate blocked, unauthorized blocked, only approved deals, rating validation, self-review blocked, non-participant blocked, summary integration, matches integration
- All 149 tests passing (137 existing + 12 new)