### PR TITLE
fix: force dynamic rendering so proxy blocks unauthenticated access

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 
+export const dynamic = "force-dynamic";
+
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -29,10 +29,7 @@ export function proxy(request: NextRequest) {
     return NextResponse.next();
   }
 
-  return NextResponse.json(
-    { error: "Forbidden", message: "Access restricted" },
-    { status: 403 }
-  );
+  return new NextResponse("Forbidden", { status: 403 });
 }
 
 export const config = {


### PR DESCRIPTION
Static pages were served from CDN cache before proxy could check auth. Adding force-dynamic to layout ensures proxy runs on every request.