### PR TITLE
feat: multi-agent project support (issue #41)

### DIFF
--- a/src/__tests__/api-projects.test.ts
+++ b/src/__tests__/api-projects.test.ts
@@ -1,0 +1,526 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createTestDb, _setDb, migrate } from "@/lib/db";
+import type { Client } from "@libsql/client";
+import { POST as projectsPOST, GET as projectsGET } from "@/app/api/projects/route";
+import { GET as projectDetailGET } from "@/app/api/projects/[projectId]/route";
+import { POST as joinPOST } from "@/app/api/projects/[projectId]/join/route";
+import { POST as messagesPOST } from "@/app/api/projects/[projectId]/messages/route";
+import { POST as approvePOST } from "@/app/api/projects/[projectId]/approve/route";
+import { POST as leavePOST } from "@/app/api/projects/[projectId]/leave/route";
+import { POST as keysPOST } from "@/app/api/keys/route";
+import { NextRequest } from "next/server";
+
+let db: Client;
+let restore: () => void;
+
+beforeEach(async () => {
+  db = createTestDb();
+  restore = _setDb(db);
+  await migrate(db);
+});
+
+afterEach(() => {
+  restore();
+});
+
+async function getApiKey(agentId: string): Promise<string> {
+  const req = new NextRequest("http://localhost:3000/api/keys", {
+    method: "POST",
+    body: JSON.stringify({ agent_id: agentId }),
+    headers: { "Content-Type": "application/json" },
+  });
+  const res = await keysPOST(req);
+  const data = await res.json();
+  return data.api_key;
+}
+
+function makeParams(projectId: string) {
+  return { params: Promise.resolve({ projectId }) };
+}
+
+async function createProject(agentId: string, apiKey: string, title: string, roles: Array<{ role_name: string; category: string }>) {
+  const req = new NextRequest("http://localhost:3000/api/projects", {
+    method: "POST",
+    body: JSON.stringify({ agent_id: agentId, title, roles }),
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+  });
+  const res = await projectsPOST(req);
+  return { res, data: await res.json() };
+}
+
+describe("POST /api/projects", () => {
+  it("creates a project with roles", async () => {
+    const key = await getApiKey("creator-agent");
+    const { res, data } = await createProject("creator-agent", key, "Build a Website", [
+      { role_name: "Frontend Dev", category: "web-development" },
+      { role_name: "Designer", category: "design" },
+    ]);
+
+    expect(res.status).toBe(201);
+    expect(data.project_id).toBeTruthy();
+    expect(data.title).toBe("Build a Website");
+    expect(data.status).toBe("open");
+    expect(data.roles).toHaveLength(2);
+    expect(data.roles[0].role_name).toBe("Frontend Dev");
+    expect(data.roles[1].role_name).toBe("Designer");
+  });
+
+  it("rejects missing title", async () => {
+    const key = await getApiKey("creator");
+    const req = new NextRequest("http://localhost:3000/api/projects", {
+      method: "POST",
+      body: JSON.stringify({ agent_id: "creator", roles: [{ role_name: "Dev", category: "dev" }] }),
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${key}` },
+    });
+    const res = await projectsPOST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects empty roles", async () => {
+    const key = await getApiKey("creator");
+    const req = new NextRequest("http://localhost:3000/api/projects", {
+      method: "POST",
+      body: JSON.stringify({ agent_id: "creator", title: "Test", roles: [] }),
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${key}` },
+    });
+    const res = await projectsPOST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects without auth", async () => {
+    const req = new NextRequest("http://localhost:3000/api/projects", {
+      method: "POST",
+      body: JSON.stringify({ agent_id: "creator", title: "Test", roles: [{ role_name: "Dev", category: "dev" }] }),
+      headers: { "Content-Type": "application/json" },
+    });
+    const res = await projectsPOST(req);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /api/projects", () => {
+  it("lists projects", async () => {
+    const key = await getApiKey("creator");
+    await createProject("creator", key, "Project 1", [{ role_name: "Dev", category: "dev" }]);
+    await createProject("creator", key, "Project 2", [{ role_name: "Designer", category: "design" }]);
+
+    const req = new NextRequest("http://localhost:3000/api/projects");
+    const res = await projectsGET(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.projects).toHaveLength(2);
+    expect(data.count).toBe(2);
+  });
+
+  it("filters by status", async () => {
+    const key = await getApiKey("creator");
+    await createProject("creator", key, "Open Project", [{ role_name: "Dev", category: "dev" }]);
+
+    const req = new NextRequest("http://localhost:3000/api/projects?status=open");
+    const res = await projectsGET(req);
+    const data = await res.json();
+
+    expect(data.projects).toHaveLength(1);
+    expect(data.projects[0].status).toBe("open");
+  });
+
+  it("filters by category", async () => {
+    const key = await getApiKey("creator");
+    await createProject("creator", key, "Dev Project", [{ role_name: "Dev", category: "web-dev" }]);
+    await createProject("creator", key, "Design Project", [{ role_name: "Designer", category: "design" }]);
+
+    const req = new NextRequest("http://localhost:3000/api/projects?category=design");
+    const res = await projectsGET(req);
+    const data = await res.json();
+
+    expect(data.projects).toHaveLength(1);
+    expect(data.projects[0].title).toBe("Design Project");
+  });
+});
+
+describe("GET /api/projects/:projectId", () => {
+  it("returns project details with roles and messages", async () => {
+    const key = await getApiKey("creator");
+    const { data: created } = await createProject("creator", key, "My Project", [
+      { role_name: "Dev", category: "dev" },
+    ]);
+
+    const req = new NextRequest(`http://localhost:3000/api/projects/${created.project_id}`);
+    const res = await projectDetailGET(req, makeParams(created.project_id));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.title).toBe("My Project");
+    expect(data.roles).toHaveLength(1);
+    expect(data.participants).toContain("creator");
+    expect(data.messages.length).toBeGreaterThan(0); // system message from creation
+  });
+
+  it("returns 404 for unknown project", async () => {
+    const req = new NextRequest("http://localhost:3000/api/projects/nonexistent");
+    const res = await projectDetailGET(req, makeParams("nonexistent"));
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /api/projects/:projectId/join", () => {
+  it("allows an agent to fill a role", async () => {
+    const creatorKey = await getApiKey("creator");
+    const joinerKey = await getApiKey("joiner");
+    const { data: project } = await createProject("creator", creatorKey, "Team Project", [
+      { role_name: "Backend Dev", category: "backend" },
+    ]);
+
+    const roleId = project.roles[0].id;
+    const req = new NextRequest(`http://localhost:3000/api/projects/${project.project_id}/join`, {
+      method: "POST",
+      body: JSON.stringify({ agent_id: "joiner", role_id: roleId }),
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${joinerKey}` },
+    });
+    const res = await joinPOST(req, makeParams(project.project_id));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.role_name).toBe("Backend Dev");
+    expect(data.agent_id).toBe("joiner");
+    expect(data.status).toBe("negotiating");
+  });
+
+  it("rejects duplicate role filling", async () => {
+    const creatorKey = await getApiKey("creator");
+    const joinerKey = await getApiKey("joiner");
+    const joiner2Key = await getApiKey("joiner2");
+    const { data: project } = await createProject("creator", creatorKey, "Team", [
+      { role_name: "Dev", category: "dev" },
+    ]);
+
+    const roleId = project.roles[0].id;
+
+    // First join succeeds
+    const req1 = new NextRequest(`http://localhost:3000/api/projects/${project.project_id}/join`, {
+      method: "POST",
+      body: JSON.stringify({ agent_id: "joiner", role_id: roleId }),
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${joinerKey}` },
+    });
+    await joinPOST(req1, makeParams(project.project_id));
+
+    // Second join to same role fails
+    const req2 = new NextRequest(`http://localhost:3000/api/projects/${project.project_id}/join`, {
+      method: "POST",
+      body: JSON.stringify({ agent_id: "joiner2", role_id: roleId }),
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${joiner2Key}` },
+    });
+    const res2 = await joinPOST(req2, makeParams(project.project_id));
+    expect(res2.status).toBe(409);
+  });
+
+  it("rejects agent joining two roles in same project", async () => {
+    const creatorKey = await getApiKey("creator");
+    const joinerKey = await getApiKey("joiner");
+    const { data: project } = await createProject("creator", creatorKey, "Team", [
+      { role_name: "Dev", category: "dev" },
+      { role_name: "QA", category: "testing" },
+    ]);
+
+    // Join first role
+    const req1 = new NextRequest(`http://localhost:3000/api/projects/${project.project_id}/join`, {
+      method: "POST",
+      body: JSON.stringify({ agent_id: "joiner", role_id: project.roles[0].id }),
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${joinerKey}` },
+    });
+    await joinPOST(req1, makeParams(project.project_id));
+
+    // Try second role
+    const req2 = new NextRequest(`http://localhost:3000/api/projects/${project.project_id}/join`, {
+      method: "POST",
+      body: JSON.stringify({ agent_id: "joiner", role_id: project.roles[1].id }),
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${joinerKey}` },
+    });
+    const res2 = await joinPOST(req2, makeParams(project.project_id));
+    expect(res2.status).toBe(409);
+  });
+});
+
+describe("POST /api/projects/:projectId/messages", () => {
+  it("allows participants to send messages", async () => {
+    const creatorKey = await getApiKey("creator");
+    const { data: project } = await createProject("creator", creatorKey, "Chat Project", [
+      { role_name: "Dev", category: "dev" },
+    ]);
+
+    const req = new NextRequest(`http://localhost:3000/api/projects/${project.project_id}/messages`, {
+      method: "POST",
+      body: JSON.stringify({ agent_id: "creator", content: "Hello team!" }),
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${creatorKey}` },
+    });
+    const res = await messagesPOST(req, makeParams(project.project_id));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.message_id).toBeTruthy();
+    expect(data.message_type).toBe("discussion");
+  });
+
+  it("rejects non-participants", async () => {
+    const creatorKey = await getApiKey("creator");
+    const outsiderKey = await getApiKey("outsider");
+    const { data: project } = await createProject("creator", creatorKey, "Private", [
+      { role_name: "Dev", category: "dev" },
+    ]);
+
+    const req = new NextRequest(`http://localhost:3000/api/projects/${project.project_id}/messages`, {
+      method: "POST",
+      body: JSON.stringify({ agent_id: "outsider", content: "Can I join?" }),
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${outsiderKey}` },
+    });
+    const res = await messagesPOST(req, makeParams(project.project_id));
+    expect(res.status).toBe(403);
+  });
+
+  it("allows role fillers to send messages", async () => {
+    const creatorKey = await getApiKey("creator");
+    const joinerKey = await getApiKey("joiner");
+    const { data: project } = await createProject("creator", creatorKey, "Team", [
+      { role_name: "Dev", category: "dev" },
+    ]);
+
+    // Join first
+    const joinReq = new NextRequest(`http://localhost:3000/api/projects/${project.project_id}/join`, {
+      method: "POST",
+      body: JSON.stringify({ agent_id: "joiner", role_id: project.roles[0].id }),
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${joinerKey}` },
+    });
+    await joinPOST(joinReq, makeParams(project.project_id));
+
+    // Then message
+    const msgReq = new NextRequest(`http://localhost:3000/api/projects/${project.project_id}/messages`, {
+      method: "POST",
+      body: JSON.stringify({ agent_id: "joiner", content: "Ready to work!" }),
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${joinerKey}` },
+    });
+    const res = await messagesPOST(msgReq, makeParams(project.project_id));
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("POST /api/projects/:projectId/approve", () => {
+  it("records approval from a participant", async () => {
+    const creatorKey = await getApiKey("creator");
+    const joinerKey = await getApiKey("joiner");
+    const { data: project } = await createProject("creator", creatorKey, "Approval Test", [
+      { role_name: "Dev", category: "dev" },
+    ]);
+
+    // Join
+    const joinReq = new NextRequest(`http://localhost:3000/api/projects/${project.project_id}/join`, {
+      method: "POST",
+      body: JSON.stringify({ agent_id: "joiner", role_id: project.roles[0].id }),
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${joinerKey}` },
+    });
+    await joinPOST(joinReq, makeParams(project.project_id));
+
+    // Creator approves
+    const approveReq = new NextRequest(`http://localhost:3000/api/projects/${project.project_id}/approve`, {
+      method: "POST",
+      body: JSON.stringify({ agent_id: "creator", approved: true }),
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${creatorKey}` },
+    });
+    const res = await approvePOST(approveReq, makeParams(project.project_id));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.all_approved).toBe(false);
+    expect(data.approvals).toBe(1);
+    expect(data.participants).toBe(2);
+  });
+
+  it("approves project when all participants approve", async () => {
+    const creatorKey = await getApiKey("creator");
+    const joinerKey = await getApiKey("joiner");
+    const { data: project } = await createProject("creator", creatorKey, "Full Approval", [
+      { role_name: "Dev", category: "dev" },
+    ]);
+
+    // Join
+    const joinReq = new NextRequest(`http://localhost:3000/api/projects/${project.project_id}/join`, {
+      method: "POST",
+      body: JSON.stringify({ agent_id: "joiner", role_id: project.roles[0].id }),
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${joinerKey}` },
+    });
+    await joinPOST(joinReq, makeParams(project.project_id));
+
+    // Both approve
+    const approve1 = new NextRequest(`http://localhost:3000/api/projects/${project.project_id}/approve`, {
+      method: "POST",
+      body: JSON.stringify({ agent_id: "creator", approved: true }),
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${creatorKey}` },
+    });
+    await approvePOST(approve1, makeParams(project.project_id));
+
+    const approve2 = new NextRequest(`http://localhost:3000/api/projects/${project.project_id}/approve`, {
+      method: "POST",
+      body: JSON.stringify({ agent_id: "joiner", approved: true }),
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${joinerKey}` },
+    });
+    const res = await approvePOST(approve2, makeParams(project.project_id));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.status).toBe("approved");
+    expect(data.all_approved).toBe(true);
+  });
+
+  it("cancels project on rejection", async () => {
+    const creatorKey = await getApiKey("creator");
+    const joinerKey = await getApiKey("joiner");
+    const { data: project } = await createProject("creator", creatorKey, "Reject Test", [
+      { role_name: "Dev", category: "dev" },
+    ]);
+
+    // Join
+    const joinReq = new NextRequest(`http://localhost:3000/api/projects/${project.project_id}/join`, {
+      method: "POST",
+      body: JSON.stringify({ agent_id: "joiner", role_id: project.roles[0].id }),
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${joinerKey}` },
+    });
+    await joinPOST(joinReq, makeParams(project.project_id));
+
+    // Reject
+    const rejectReq = new NextRequest(`http://localhost:3000/api/projects/${project.project_id}/approve`, {
+      method: "POST",
+      body: JSON.stringify({ agent_id: "joiner", approved: false }),
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${joinerKey}` },
+    });
+    const res = await approvePOST(rejectReq, makeParams(project.project_id));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.status).toBe("cancelled");
+  });
+});
+
+describe("POST /api/projects/:projectId/leave", () => {
+  it("allows a member to leave and vacate their role", async () => {
+    const creatorKey = await getApiKey("creator");
+    const joinerKey = await getApiKey("joiner");
+    const { data: project } = await createProject("creator", creatorKey, "Leave Test", [
+      { role_name: "Dev", category: "dev" },
+    ]);
+
+    // Join
+    const joinReq = new NextRequest(`http://localhost:3000/api/projects/${project.project_id}/join`, {
+      method: "POST",
+      body: JSON.stringify({ agent_id: "joiner", role_id: project.roles[0].id }),
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${joinerKey}` },
+    });
+    await joinPOST(joinReq, makeParams(project.project_id));
+
+    // Leave
+    const leaveReq = new NextRequest(`http://localhost:3000/api/projects/${project.project_id}/leave`, {
+      method: "POST",
+      body: JSON.stringify({ agent_id: "joiner" }),
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${joinerKey}` },
+    });
+    const res = await leavePOST(leaveReq, makeParams(project.project_id));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.role_vacated).toBe("Dev");
+    expect(data.status).toBe("open");
+  });
+
+  it("prevents creator from leaving", async () => {
+    const creatorKey = await getApiKey("creator");
+    const { data: project } = await createProject("creator", creatorKey, "Creator Leave", [
+      { role_name: "Dev", category: "dev" },
+    ]);
+
+    const leaveReq = new NextRequest(`http://localhost:3000/api/projects/${project.project_id}/leave`, {
+      method: "POST",
+      body: JSON.stringify({ agent_id: "creator" }),
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${creatorKey}` },
+    });
+    const res = await leavePOST(leaveReq, makeParams(project.project_id));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects non-participants", async () => {
+    const creatorKey = await getApiKey("creator");
+    const outsiderKey = await getApiKey("outsider");
+    const { data: project } = await createProject("creator", creatorKey, "Private", [
+      { role_name: "Dev", category: "dev" },
+    ]);
+
+    const leaveReq = new NextRequest(`http://localhost:3000/api/projects/${project.project_id}/leave`, {
+      method: "POST",
+      body: JSON.stringify({ agent_id: "outsider" }),
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${outsiderKey}` },
+    });
+    const res = await leavePOST(leaveReq, makeParams(project.project_id));
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("full project lifecycle", () => {
+  it("create -> join -> message -> approve -> approved", async () => {
+    const creatorKey = await getApiKey("creator");
+    const dev1Key = await getApiKey("dev1");
+    const dev2Key = await getApiKey("dev2");
+
+    // Create project with 2 roles
+    const { data: project } = await createProject("creator", creatorKey, "Full Stack App", [
+      { role_name: "Frontend Dev", category: "frontend" },
+      { role_name: "Backend Dev", category: "backend" },
+    ]);
+    expect(project.roles).toHaveLength(2);
+
+    // Dev1 joins frontend
+    const join1 = new NextRequest(`http://localhost:3000/api/projects/${project.project_id}/join`, {
+      method: "POST",
+      body: JSON.stringify({ agent_id: "dev1", role_id: project.roles[0].id }),
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${dev1Key}` },
+    });
+    const join1Res = await joinPOST(join1, makeParams(project.project_id));
+    expect(join1Res.status).toBe(200);
+
+    // Dev2 joins backend
+    const join2 = new NextRequest(`http://localhost:3000/api/projects/${project.project_id}/join`, {
+      method: "POST",
+      body: JSON.stringify({ agent_id: "dev2", role_id: project.roles[1].id }),
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${dev2Key}` },
+    });
+    const join2Res = await joinPOST(join2, makeParams(project.project_id));
+    const join2Data = await join2Res.json();
+    expect(join2Data.all_roles_filled).toBe(true);
+
+    // Group discussion
+    const msgReq = new NextRequest(`http://localhost:3000/api/projects/${project.project_id}/messages`, {
+      method: "POST",
+      body: JSON.stringify({ agent_id: "creator", content: "Welcome everyone! Let's build something great." }),
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${creatorKey}` },
+    });
+    await messagesPOST(msgReq, makeParams(project.project_id));
+
+    // All three approve
+    for (const [agentId, key] of [["creator", creatorKey], ["dev1", dev1Key], ["dev2", dev2Key]]) {
+      const approveReq = new NextRequest(`http://localhost:3000/api/projects/${project.project_id}/approve`, {
+        method: "POST",
+        body: JSON.stringify({ agent_id: agentId, approved: true }),
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${key}` },
+      });
+      await approvePOST(approveReq, makeParams(project.project_id));
+    }
+
+    // Verify final state
+    const detailReq = new NextRequest(`http://localhost:3000/api/projects/${project.project_id}`);
+    const detailRes = await projectDetailGET(detailReq, makeParams(project.project_id));
+    const detail = await detailRes.json();
+
+    expect(detail.status).toBe("approved");
+    expect(detail.participants).toHaveLength(3);
+    expect(detail.roles_filled).toBe(2);
+    expect(detail.approvals).toHaveLength(3);
+    expect(detail.messages.length).toBeGreaterThanOrEqual(4); // system + creation + joins + discussion
+  });
+});

--- a/src/app/api/projects/[projectId]/approve/route.ts
+++ b/src/app/api/projects/[projectId]/approve/route.ts
@@ -1,0 +1,165 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ensureDb } from "@/lib/db";
+import { authenticateRequest } from "@/lib/auth";
+import { checkRateLimit, RATE_LIMITS } from "@/lib/rate-limit";
+import { createNotification } from "@/lib/notifications";
+import type { Project } from "@/lib/types";
+
+/** POST /api/projects/:projectId/approve - Approve/reject the project */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ projectId: string }> }
+) {
+  const rateLimited = checkRateLimit(req, RATE_LIMITS.WRITE.limit, RATE_LIMITS.WRITE.windowMs, RATE_LIMITS.WRITE.prefix);
+  if (rateLimited) return rateLimited;
+
+  const auth = await authenticateRequest(req);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { projectId } = await params;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const b = body as Record<string, unknown>;
+
+  if (!b.agent_id || typeof b.agent_id !== "string") {
+    return NextResponse.json({ error: "agent_id is required" }, { status: 400 });
+  }
+  if (b.agent_id !== auth.agent_id) {
+    return NextResponse.json({ error: "agent_id does not match authenticated key" }, { status: 403 });
+  }
+  if (typeof b.approved !== "boolean") {
+    return NextResponse.json({ error: "approved (boolean) is required" }, { status: 400 });
+  }
+
+  const db = await ensureDb();
+
+  // Get project
+  const projectResult = await db.execute({
+    sql: "SELECT * FROM projects WHERE id = ?",
+    args: [projectId],
+  });
+  const project = projectResult.rows[0] as unknown as Project | undefined;
+
+  if (!project) {
+    return NextResponse.json({ error: "Project not found" }, { status: 404 });
+  }
+
+  if (project.status === "completed" || project.status === "cancelled") {
+    return NextResponse.json({ error: `Project is ${project.status}` }, { status: 400 });
+  }
+
+  // Verify agent is a participant
+  const isCreator = project.creator_agent_id === b.agent_id;
+  const roleResult = await db.execute({
+    sql: "SELECT * FROM project_roles WHERE project_id = ? AND filled_by_agent_id = ?",
+    args: [projectId, b.agent_id],
+  });
+  const isRoleFiller = roleResult.rows.length > 0;
+
+  if (!isCreator && !isRoleFiller) {
+    return NextResponse.json({ error: "Agent is not a participant in this project" }, { status: 403 });
+  }
+
+  // Record approval
+  await db.execute({
+    sql: `INSERT OR REPLACE INTO project_approvals (project_id, agent_id, approved) VALUES (?, ?, ?)`,
+    args: [projectId, b.agent_id, b.approved ? 1 : 0],
+  });
+
+  // System message
+  await db.execute({
+    sql: "INSERT INTO project_messages (project_id, sender_agent_id, content, message_type) VALUES (?, ?, ?, 'system')",
+    args: [projectId, b.agent_id, `${b.agent_id} ${b.approved ? "approved" : "rejected"} the project`],
+  });
+
+  // Get all participants
+  const allRolesResult = await db.execute({
+    sql: "SELECT filled_by_agent_id FROM project_roles WHERE project_id = ? AND filled_by_agent_id IS NOT NULL",
+    args: [projectId],
+  });
+  const participants = new Set<string>();
+  participants.add(project.creator_agent_id);
+  for (const r of allRolesResult.rows) {
+    participants.add(r.filled_by_agent_id as string);
+  }
+
+  // If rejected, notify everyone
+  if (!b.approved) {
+    for (const pid of participants) {
+      if (pid === b.agent_id) continue;
+      await createNotification(db, {
+        agent_id: pid,
+        type: "project_cancelled",
+        from_agent_id: b.agent_id as string,
+        summary: `${b.agent_id} rejected project "${project.title}"`,
+      });
+    }
+    // Cancel project on any rejection
+    await db.execute({
+      sql: "UPDATE projects SET status = 'cancelled' WHERE id = ?",
+      args: [projectId],
+    });
+    return NextResponse.json({ project_id: projectId, status: "cancelled", reason: "rejected" });
+  }
+
+  // Check if all participants have approved
+  const approvalsResult = await db.execute({
+    sql: "SELECT agent_id FROM project_approvals WHERE project_id = ? AND approved = 1",
+    args: [projectId],
+  });
+  const approvedAgents = new Set(approvalsResult.rows.map(r => r.agent_id as string));
+  const allApproved = [...participants].every(p => approvedAgents.has(p));
+
+  if (allApproved) {
+    await db.execute({
+      sql: "UPDATE projects SET status = 'approved' WHERE id = ?",
+      args: [projectId],
+    });
+
+    // Notify all
+    for (const pid of participants) {
+      await createNotification(db, {
+        agent_id: pid,
+        type: "project_approved",
+        from_agent_id: b.agent_id as string,
+        summary: `Project "${project.title}" has been approved by all participants!`,
+      });
+    }
+
+    return NextResponse.json({
+      project_id: projectId,
+      status: "approved",
+      approvals: approvalsResult.rows.length,
+      participants: participants.size,
+      all_approved: true,
+    });
+  }
+
+  // Notify others about this approval
+  for (const pid of participants) {
+    if (pid === b.agent_id) continue;
+    await createNotification(db, {
+      agent_id: pid,
+      type: "project_proposed",
+      from_agent_id: b.agent_id as string,
+      summary: `${b.agent_id} approved project "${project.title}" (${approvedAgents.size}/${participants.size})`,
+    });
+  }
+
+  return NextResponse.json({
+    project_id: projectId,
+    status: project.status,
+    approvals: approvedAgents.size,
+    participants: participants.size,
+    all_approved: false,
+    remaining: [...participants].filter(p => !approvedAgents.has(p)),
+  });
+}

--- a/src/app/api/projects/[projectId]/join/route.ts
+++ b/src/app/api/projects/[projectId]/join/route.ts
@@ -1,0 +1,131 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ensureDb } from "@/lib/db";
+import { authenticateRequest } from "@/lib/auth";
+import { checkRateLimit, RATE_LIMITS } from "@/lib/rate-limit";
+import { createNotification } from "@/lib/notifications";
+import type { Project, ProjectRole } from "@/lib/types";
+
+/** POST /api/projects/:projectId/join - Apply to fill a role */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ projectId: string }> }
+) {
+  const rateLimited = checkRateLimit(req, RATE_LIMITS.WRITE.limit, RATE_LIMITS.WRITE.windowMs, RATE_LIMITS.WRITE.prefix);
+  if (rateLimited) return rateLimited;
+
+  const auth = await authenticateRequest(req);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { projectId } = await params;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const b = body as Record<string, unknown>;
+
+  if (!b.agent_id || typeof b.agent_id !== "string") {
+    return NextResponse.json({ error: "agent_id is required" }, { status: 400 });
+  }
+  if (b.agent_id !== auth.agent_id) {
+    return NextResponse.json({ error: "agent_id does not match authenticated key" }, { status: 403 });
+  }
+  if (!b.role_id || typeof b.role_id !== "string") {
+    return NextResponse.json({ error: "role_id is required" }, { status: 400 });
+  }
+
+  const db = await ensureDb();
+
+  // Get project
+  const projectResult = await db.execute({
+    sql: "SELECT * FROM projects WHERE id = ?",
+    args: [projectId],
+  });
+  const project = projectResult.rows[0] as unknown as Project | undefined;
+
+  if (!project) {
+    return NextResponse.json({ error: "Project not found" }, { status: 404 });
+  }
+
+  if (project.status !== "open" && project.status !== "negotiating") {
+    return NextResponse.json({ error: `Project is ${project.status}, cannot join` }, { status: 400 });
+  }
+
+  // Get role
+  const roleResult = await db.execute({
+    sql: "SELECT * FROM project_roles WHERE id = ? AND project_id = ?",
+    args: [b.role_id, projectId],
+  });
+  const role = roleResult.rows[0] as unknown as ProjectRole | undefined;
+
+  if (!role) {
+    return NextResponse.json({ error: "Role not found in this project" }, { status: 404 });
+  }
+
+  if (role.filled_by_agent_id) {
+    return NextResponse.json({ error: "Role is already filled" }, { status: 409 });
+  }
+
+  // Check agent isn't already filling another role in this project
+  const existingResult = await db.execute({
+    sql: "SELECT id, role_name FROM project_roles WHERE project_id = ? AND filled_by_agent_id = ?",
+    args: [projectId, b.agent_id],
+  });
+  if (existingResult.rows.length > 0) {
+    return NextResponse.json({ error: "Agent already fills a role in this project" }, { status: 409 });
+  }
+
+  // Optionally link a profile
+  const profileId = typeof b.profile_id === "string" ? b.profile_id : null;
+
+  // Fill the role
+  await db.execute({
+    sql: "UPDATE project_roles SET filled_by_agent_id = ?, filled_by_profile_id = ? WHERE id = ?",
+    args: [b.agent_id, profileId, b.role_id],
+  });
+
+  // Update project status to negotiating if still open
+  if (project.status === "open") {
+    await db.execute({
+      sql: "UPDATE projects SET status = 'negotiating' WHERE id = ?",
+      args: [projectId],
+    });
+  }
+
+  // System message
+  await db.execute({
+    sql: "INSERT INTO project_messages (project_id, sender_agent_id, content, message_type) VALUES (?, ?, ?, 'system')",
+    args: [projectId, b.agent_id, `${b.agent_id} joined as ${role.role_name}`],
+  });
+
+  // Notify creator
+  if (project.creator_agent_id !== b.agent_id) {
+    await createNotification(db, {
+      agent_id: project.creator_agent_id,
+      type: "project_role_filled",
+      from_agent_id: b.agent_id as string,
+      summary: `${b.agent_id} joined project "${project.title}" as ${role.role_name}`,
+    });
+  }
+
+  // Check if all roles are now filled
+  const unfilledResult = await db.execute({
+    sql: "SELECT COUNT(*) as cnt FROM project_roles WHERE project_id = ? AND filled_by_agent_id IS NULL",
+    args: [projectId],
+  });
+  const unfilled = Number(unfilledResult.rows[0].cnt);
+
+  return NextResponse.json({
+    project_id: projectId,
+    role_id: b.role_id,
+    role_name: role.role_name,
+    agent_id: b.agent_id,
+    all_roles_filled: unfilled === 0,
+    status: project.status === "open" ? "negotiating" : project.status,
+  });
+}

--- a/src/app/api/projects/[projectId]/leave/route.ts
+++ b/src/app/api/projects/[projectId]/leave/route.ts
@@ -1,0 +1,113 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ensureDb } from "@/lib/db";
+import { authenticateRequest } from "@/lib/auth";
+import { checkRateLimit, RATE_LIMITS } from "@/lib/rate-limit";
+import { createNotification } from "@/lib/notifications";
+import type { Project } from "@/lib/types";
+
+/** POST /api/projects/:projectId/leave - Leave a project (vacate role) */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ projectId: string }> }
+) {
+  const rateLimited = checkRateLimit(req, RATE_LIMITS.WRITE.limit, RATE_LIMITS.WRITE.windowMs, RATE_LIMITS.WRITE.prefix);
+  if (rateLimited) return rateLimited;
+
+  const auth = await authenticateRequest(req);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { projectId } = await params;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const b = body as Record<string, unknown>;
+
+  if (!b.agent_id || typeof b.agent_id !== "string") {
+    return NextResponse.json({ error: "agent_id is required" }, { status: 400 });
+  }
+  if (b.agent_id !== auth.agent_id) {
+    return NextResponse.json({ error: "agent_id does not match authenticated key" }, { status: 403 });
+  }
+
+  const db = await ensureDb();
+
+  // Get project
+  const projectResult = await db.execute({
+    sql: "SELECT * FROM projects WHERE id = ?",
+    args: [projectId],
+  });
+  const project = projectResult.rows[0] as unknown as Project | undefined;
+
+  if (!project) {
+    return NextResponse.json({ error: "Project not found" }, { status: 404 });
+  }
+
+  if (project.status === "completed" || project.status === "cancelled") {
+    return NextResponse.json({ error: `Project is ${project.status}, cannot leave` }, { status: 400 });
+  }
+
+  // Creator can't leave (they should cancel instead)
+  if (project.creator_agent_id === b.agent_id) {
+    return NextResponse.json({ error: "Project creator cannot leave. Use cancel instead." }, { status: 400 });
+  }
+
+  // Check if agent fills a role
+  const roleResult = await db.execute({
+    sql: "SELECT id, role_name FROM project_roles WHERE project_id = ? AND filled_by_agent_id = ?",
+    args: [projectId, b.agent_id],
+  });
+
+  if (roleResult.rows.length === 0) {
+    return NextResponse.json({ error: "Agent is not a participant in this project" }, { status: 400 });
+  }
+
+  const roleName = roleResult.rows[0].role_name as string;
+
+  // Vacate the role
+  await db.execute({
+    sql: "UPDATE project_roles SET filled_by_agent_id = NULL, filled_by_profile_id = NULL WHERE project_id = ? AND filled_by_agent_id = ?",
+    args: [projectId, b.agent_id],
+  });
+
+  // Remove approval
+  await db.execute({
+    sql: "DELETE FROM project_approvals WHERE project_id = ? AND agent_id = ?",
+    args: [projectId, b.agent_id],
+  });
+
+  // Revert to open status if we were in negotiating/proposed
+  if (project.status === "negotiating" || project.status === "proposed" || project.status === "approved") {
+    await db.execute({
+      sql: "UPDATE projects SET status = 'open' WHERE id = ?",
+      args: [projectId],
+    });
+  }
+
+  // System message
+  await db.execute({
+    sql: "INSERT INTO project_messages (project_id, sender_agent_id, content, message_type) VALUES (?, ?, ?, 'system')",
+    args: [projectId, b.agent_id, `${b.agent_id} left the project (role: ${roleName})`],
+  });
+
+  // Notify creator
+  await createNotification(db, {
+    agent_id: project.creator_agent_id,
+    type: "project_member_left",
+    from_agent_id: b.agent_id as string,
+    summary: `${b.agent_id} left project "${project.title}" (role: ${roleName})`,
+  });
+
+  return NextResponse.json({
+    project_id: projectId,
+    agent_id: b.agent_id,
+    role_vacated: roleName,
+    status: "open",
+  });
+}

--- a/src/app/api/projects/[projectId]/messages/route.ts
+++ b/src/app/api/projects/[projectId]/messages/route.ts
@@ -1,0 +1,119 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ensureDb } from "@/lib/db";
+import { authenticateRequest } from "@/lib/auth";
+import { checkRateLimit, RATE_LIMITS } from "@/lib/rate-limit";
+import { createNotification } from "@/lib/notifications";
+import type { Project } from "@/lib/types";
+
+/** POST /api/projects/:projectId/messages - Send a message to the project thread */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ projectId: string }> }
+) {
+  const rateLimited = checkRateLimit(req, RATE_LIMITS.WRITE.limit, RATE_LIMITS.WRITE.windowMs, RATE_LIMITS.WRITE.prefix);
+  if (rateLimited) return rateLimited;
+
+  const auth = await authenticateRequest(req);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { projectId } = await params;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const b = body as Record<string, unknown>;
+
+  if (!b.agent_id || typeof b.agent_id !== "string") {
+    return NextResponse.json({ error: "agent_id is required" }, { status: 400 });
+  }
+  if (b.agent_id !== auth.agent_id) {
+    return NextResponse.json({ error: "agent_id does not match authenticated key" }, { status: 403 });
+  }
+  if (!b.content || typeof b.content !== "string" || b.content.trim().length === 0) {
+    return NextResponse.json({ error: "content is required" }, { status: 400 });
+  }
+
+  const db = await ensureDb();
+
+  // Get project
+  const projectResult = await db.execute({
+    sql: "SELECT * FROM projects WHERE id = ?",
+    args: [projectId],
+  });
+  const project = projectResult.rows[0] as unknown as Project | undefined;
+
+  if (!project) {
+    return NextResponse.json({ error: "Project not found" }, { status: 404 });
+  }
+
+  // Check terminal states
+  if (project.status === "completed" || project.status === "cancelled") {
+    return NextResponse.json({ error: `Project is ${project.status}, no further messages allowed` }, { status: 400 });
+  }
+
+  // Verify agent is a participant (creator or role filler)
+  const isCreator = project.creator_agent_id === b.agent_id;
+  const roleResult = await db.execute({
+    sql: "SELECT * FROM project_roles WHERE project_id = ? AND filled_by_agent_id = ?",
+    args: [projectId, b.agent_id],
+  });
+  const isRoleFiller = roleResult.rows.length > 0;
+
+  if (!isCreator && !isRoleFiller) {
+    return NextResponse.json({ error: "Agent is not a participant in this project" }, { status: 403 });
+  }
+
+  let messageType = (b.message_type as string) ?? "discussion";
+  if (messageType === "text") messageType = "discussion";
+  if (!["discussion", "proposal", "system"].includes(messageType)) {
+    return NextResponse.json({ error: "message_type must be 'discussion', 'proposal', or 'text'" }, { status: 400 });
+  }
+
+  // Insert message
+  const result = await db.execute({
+    sql: "INSERT INTO project_messages (project_id, sender_agent_id, content, message_type) VALUES (?, ?, ?, ?)",
+    args: [projectId, b.agent_id, b.content.trim(), messageType],
+  });
+
+  // Update status if proposal
+  if (messageType === "proposal" && (project.status === "open" || project.status === "negotiating")) {
+    await db.execute({
+      sql: "UPDATE projects SET status = 'proposed' WHERE id = ?",
+      args: [projectId],
+    });
+  }
+
+  // Notify all other participants
+  const allRolesResult = await db.execute({
+    sql: "SELECT filled_by_agent_id FROM project_roles WHERE project_id = ? AND filled_by_agent_id IS NOT NULL",
+    args: [projectId],
+  });
+  const participants = new Set<string>();
+  participants.add(project.creator_agent_id);
+  for (const r of allRolesResult.rows) {
+    participants.add(r.filled_by_agent_id as string);
+  }
+  participants.delete(b.agent_id as string); // Don't notify sender
+
+  for (const pid of participants) {
+    await createNotification(db, {
+      agent_id: pid,
+      type: "project_message",
+      from_agent_id: b.agent_id as string,
+      summary: `New message from ${b.agent_id} in project "${project.title}"`,
+    });
+  }
+
+  return NextResponse.json({
+    message_id: Number(result.lastInsertRowid),
+    project_id: projectId,
+    message_type: messageType,
+    status: messageType === "proposal" ? "proposed" : project.status,
+  });
+}

--- a/src/app/api/projects/[projectId]/route.ts
+++ b/src/app/api/projects/[projectId]/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ensureDb } from "@/lib/db";
+import { checkRateLimit, RATE_LIMITS } from "@/lib/rate-limit";
+import type { Project } from "@/lib/types";
+
+/** GET /api/projects/:projectId - Project details with roles, participants, messages */
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ projectId: string }> }
+) {
+  const rateLimited = checkRateLimit(req, RATE_LIMITS.READ.limit, RATE_LIMITS.READ.windowMs, RATE_LIMITS.READ.prefix);
+  if (rateLimited) return rateLimited;
+
+  const { projectId } = await params;
+  const db = await ensureDb();
+
+  const projectResult = await db.execute({
+    sql: "SELECT * FROM projects WHERE id = ?",
+    args: [projectId],
+  });
+  const project = projectResult.rows[0] as unknown as Project | undefined;
+
+  if (!project) {
+    return NextResponse.json({ error: "Project not found" }, { status: 404 });
+  }
+
+  // Get roles
+  const rolesResult = await db.execute({
+    sql: "SELECT * FROM project_roles WHERE project_id = ? ORDER BY created_at",
+    args: [projectId],
+  });
+  const roles = rolesResult.rows.map(r => ({
+    id: r.id,
+    role_name: r.role_name,
+    category: r.category,
+    requirements: JSON.parse(r.requirements as string || "{}"),
+    filled_by_agent_id: r.filled_by_agent_id,
+    filled: !!r.filled_by_agent_id,
+  }));
+
+  // Get participants (creator + agents who filled roles)
+  const participants = new Set<string>();
+  participants.add(project.creator_agent_id);
+  for (const role of roles) {
+    if (role.filled_by_agent_id) participants.add(role.filled_by_agent_id as string);
+  }
+
+  // Get messages (last 50)
+  const { searchParams } = new URL(req.url);
+  const messageLimit = Math.min(parseInt(searchParams.get("message_limit") || "50"), 100);
+  const messagesResult = await db.execute({
+    sql: "SELECT * FROM project_messages WHERE project_id = ? ORDER BY created_at DESC LIMIT ?",
+    args: [projectId, messageLimit],
+  });
+  const messages = messagesResult.rows.reverse().map(m => ({
+    id: m.id,
+    sender_agent_id: m.sender_agent_id,
+    content: m.content,
+    message_type: m.message_type,
+    created_at: m.created_at,
+  }));
+
+  // Get approvals
+  const approvalsResult = await db.execute({
+    sql: "SELECT * FROM project_approvals WHERE project_id = ?",
+    args: [projectId],
+  });
+  const approvals = approvalsResult.rows.map(a => ({
+    agent_id: a.agent_id,
+    approved: !!a.approved,
+    created_at: a.created_at,
+  }));
+
+  return NextResponse.json({
+    id: project.id,
+    creator_agent_id: project.creator_agent_id,
+    title: project.title,
+    description: project.description,
+    status: project.status,
+    max_participants: project.max_participants,
+    roles,
+    participants: Array.from(participants),
+    participant_count: participants.size,
+    roles_filled: roles.filter(r => r.filled).length,
+    roles_total: roles.length,
+    messages,
+    approvals,
+    created_at: project.created_at,
+  });
+}

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -1,0 +1,160 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ensureDb } from "@/lib/db";
+import { authenticateRequest } from "@/lib/auth";
+import { checkRateLimit, RATE_LIMITS } from "@/lib/rate-limit";
+import { randomUUID } from "crypto";
+import type { InValue } from "@libsql/client";
+
+/** POST /api/projects - Create a project with roles */
+export async function POST(req: NextRequest) {
+  const rateLimited = checkRateLimit(req, RATE_LIMITS.WRITE.limit, RATE_LIMITS.WRITE.windowMs, RATE_LIMITS.WRITE.prefix);
+  if (rateLimited) return rateLimited;
+
+  const auth = await authenticateRequest(req);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const b = body as Record<string, unknown>;
+
+  if (!b.agent_id || typeof b.agent_id !== "string") {
+    return NextResponse.json({ error: "agent_id is required" }, { status: 400 });
+  }
+  if (b.agent_id !== auth.agent_id) {
+    return NextResponse.json({ error: "agent_id does not match authenticated key" }, { status: 403 });
+  }
+  if (!b.title || typeof b.title !== "string" || b.title.trim().length === 0) {
+    return NextResponse.json({ error: "title is required" }, { status: 400 });
+  }
+  if (!Array.isArray(b.roles) || b.roles.length === 0) {
+    return NextResponse.json({ error: "roles is required and must be a non-empty array" }, { status: 400 });
+  }
+  if (b.roles.length > 20) {
+    return NextResponse.json({ error: "Maximum 20 roles per project" }, { status: 400 });
+  }
+
+  // Validate each role
+  for (const role of b.roles) {
+    if (!role || typeof role !== "object") {
+      return NextResponse.json({ error: "Each role must be an object" }, { status: 400 });
+    }
+    const r = role as Record<string, unknown>;
+    if (!r.role_name || typeof r.role_name !== "string") {
+      return NextResponse.json({ error: "Each role must have a role_name" }, { status: 400 });
+    }
+    if (!r.category || typeof r.category !== "string") {
+      return NextResponse.json({ error: "Each role must have a category" }, { status: 400 });
+    }
+  }
+
+  const db = await ensureDb();
+  const projectId = randomUUID();
+  const maxParticipants = typeof b.max_participants === "number" ? Math.min(Math.max(b.max_participants, 2), 20) : 10;
+
+  await db.execute({
+    sql: "INSERT INTO projects (id, creator_agent_id, title, description, status, max_participants) VALUES (?, ?, ?, ?, 'open', ?)",
+    args: [projectId, b.agent_id, b.title.trim(), (b.description as string)?.trim() || null, maxParticipants],
+  });
+
+  const roles: Array<{ id: string; role_name: string; category: string }> = [];
+  for (const role of b.roles) {
+    const r = role as Record<string, unknown>;
+    const roleId = randomUUID();
+    await db.execute({
+      sql: "INSERT INTO project_roles (id, project_id, role_name, category, requirements) VALUES (?, ?, ?, ?, ?)",
+      args: [roleId, projectId, (r.role_name as string).trim(), (r.category as string).trim(), r.requirements ? JSON.stringify(r.requirements) : "{}"],
+    });
+    roles.push({ id: roleId, role_name: (r.role_name as string).trim(), category: (r.category as string).trim() });
+  }
+
+  // Auto-add system message
+  await db.execute({
+    sql: "INSERT INTO project_messages (project_id, sender_agent_id, content, message_type) VALUES (?, ?, ?, 'system')",
+    args: [projectId, b.agent_id, `Project "${b.title}" created by ${b.agent_id} with ${roles.length} role(s)`],
+  });
+
+  return NextResponse.json({
+    project_id: projectId,
+    title: b.title,
+    status: "open",
+    roles,
+    max_participants: maxParticipants,
+  }, { status: 201 });
+}
+
+/** GET /api/projects - List/search projects */
+export async function GET(req: NextRequest) {
+  const rateLimited = checkRateLimit(req, RATE_LIMITS.READ.limit, RATE_LIMITS.READ.windowMs, RATE_LIMITS.READ.prefix);
+  if (rateLimited) return rateLimited;
+
+  const db = await ensureDb();
+  const { searchParams } = new URL(req.url);
+  const status = searchParams.get("status");
+  const category = searchParams.get("category");
+  const creatorId = searchParams.get("creator_id");
+  const limit = Math.min(parseInt(searchParams.get("limit") || "20"), 50);
+
+  let sql = "SELECT * FROM projects WHERE 1=1";
+  const args: InValue[] = [];
+
+  if (status) {
+    sql += " AND status = ?";
+    args.push(status);
+  }
+  if (creatorId) {
+    sql += " AND creator_agent_id = ?";
+    args.push(creatorId);
+  }
+
+  sql += " ORDER BY created_at DESC LIMIT ?";
+  args.push(limit);
+
+  const result = await db.execute({ sql, args });
+  const projects = result.rows;
+
+  // Get roles for each project, optionally filter by category
+  const enriched = [];
+  for (const p of projects) {
+    let roleSql = "SELECT * FROM project_roles WHERE project_id = ?";
+    const roleArgs: InValue[] = [p.id as string];
+    if (category) {
+      roleSql += " AND category = ?";
+      roleArgs.push(category);
+    }
+    const rolesResult = await db.execute({ sql: roleSql, args: roleArgs });
+    
+    // If filtering by category and no roles match, skip this project
+    if (category && rolesResult.rows.length === 0) continue;
+
+    const roles = rolesResult.rows.map(r => ({
+      id: r.id,
+      role_name: r.role_name,
+      category: r.category,
+      requirements: JSON.parse(r.requirements as string || "{}"),
+      filled_by_agent_id: r.filled_by_agent_id,
+      filled: !!r.filled_by_agent_id,
+    }));
+
+    enriched.push({
+      id: p.id,
+      creator_agent_id: p.creator_agent_id,
+      title: p.title,
+      description: p.description,
+      status: p.status,
+      max_participants: p.max_participants,
+      roles,
+      roles_filled: roles.filter(r => r.filled).length,
+      roles_total: roles.length,
+      created_at: p.created_at,
+    });
+  }
+
+  return NextResponse.json({ projects: enriched, count: enriched.length });
+}

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -13,7 +13,15 @@ export type NotificationType =
   | "deal_completed"
   | "deal_completion_requested"
   | "milestone_updated"
-  | "milestone_created";
+  | "milestone_created"
+  | "project_role_filled"
+  | "project_message"
+  | "project_proposed"
+  | "project_approved"
+  | "project_started"
+  | "project_completed"
+  | "project_cancelled"
+  | "project_member_left";
 
 export interface CreateNotification {
   agent_id: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -64,6 +64,48 @@ export interface OverlapSummary {
   score: number;
 }
 
+// Project types (multi-agent deals)
+
+export type ProjectStatus = "open" | "negotiating" | "proposed" | "approved" | "in_progress" | "completed" | "cancelled";
+
+export interface Project {
+  id: string;
+  creator_agent_id: string;
+  title: string;
+  description: string | null;
+  status: ProjectStatus;
+  max_participants: number;
+  created_at: string;
+}
+
+export interface ProjectRole {
+  id: string;
+  project_id: string;
+  role_name: string;
+  category: string;
+  requirements: string;
+  filled_by_agent_id: string | null;
+  filled_by_profile_id: string | null;
+  created_at: string;
+}
+
+export interface ProjectMessage {
+  id: number;
+  project_id: string;
+  sender_agent_id: string;
+  content: string;
+  message_type: string;
+  created_at: string;
+}
+
+export interface ProjectApproval {
+  id: number;
+  project_id: string;
+  agent_id: string;
+  approved: number;
+  created_at: string;
+}
+
 // API request types
 
 export interface ConnectRequest {


### PR DESCRIPTION
## Multi-Agent Deal Support

Adds group collaboration projects - a major differentiator for the platform. Agents can now assemble teams, not just 1:1 matching.

### New Endpoints (7)
- `POST /api/projects` - Create project with roles
- `GET /api/projects` - List/search (status, category, creator filters)
- `GET /api/projects/:id` - Details with roles, messages, approvals
- `POST /api/projects/:id/join` - Fill a role
- `POST /api/projects/:id/messages` - Group messaging
- `POST /api/projects/:id/approve` - Individual approval (consensus required)
- `POST /api/projects/:id/leave` - Vacate a role

### Key Features
- Role-based team assembly (up to 20 roles per project)
- Full lifecycle: open -> negotiating -> proposed -> approved -> in_progress -> completed
- Auto-cancel on any rejection
- Notifications for all events (role filled, messages, approvals, etc.)
- System messages track project history

### Tests
22 new tests including full lifecycle test (create -> join -> message -> approve)
233 total tests passing, TypeScript clean.

Closes #41