### PR TITLE
fix: proxy allows Bearer tokens + public routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.env*.local

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,35 +1,65 @@
 import { NextRequest, NextResponse } from "next/server";
+import { verifyToken } from "@/app/api/auth/login/route";
 
 const ALLOWED_IPS = (process.env.ALLOWED_IPS || "").split(",").filter(Boolean);
 const API_SECRET = process.env.API_SECRET || "";
+const COOKIE_NAME = "lc_session";
+
+const PUBLIC_PATHS = [
+  "/login",
+  "/api/auth/login",
+  "/api/keys",
+  "/api/stats",
+  "/api/categories",
+  "/api/tags",
+  "/api/search",
+  "/api/projects",
+];
+
+function isPublicPath(pathname: string): boolean {
+  return PUBLIC_PATHS.some(p => pathname === p || pathname.startsWith(p + "/"));
+}
 
 export function proxy(request: NextRequest) {
-  // Skip protection in development/test
+  const { pathname } = request.nextUrl;
+
   if (process.env.NODE_ENV === "development" || process.env.VITEST) {
     return NextResponse.next();
   }
 
-  // Check API secret header first (agents can use this)
+  if (isPublicPath(pathname)) {
+    return NextResponse.next();
+  }
+
   const secret = request.headers.get("x-api-secret");
   if (API_SECRET && secret === API_SECRET) {
     return NextResponse.next();
   }
 
-  // Check IP allowlist
+  const authHeader = request.headers.get("authorization");
+  if (authHeader?.startsWith("Bearer lc_")) {
+    return NextResponse.next();
+  }
+
   const forwarded = request.headers.get("x-forwarded-for");
   const ip = forwarded?.split(",")[0]?.trim() || request.headers.get("x-real-ip") || "";
-
   if (ALLOWED_IPS.length > 0 && ALLOWED_IPS.includes(ip)) {
     return NextResponse.next();
   }
 
-  // Check Vercel deployment protection bypass (for Vercel Password Protection)
-  const bypassCookie = request.cookies.get("_vercel_jwt");
-  if (bypassCookie) {
+  const sessionCookie = request.cookies.get(COOKIE_NAME);
+  if (sessionCookie && verifyToken(sessionCookie.value)) {
     return NextResponse.next();
   }
 
-  return new NextResponse("Forbidden", { status: 403 });
+  if (pathname.startsWith("/api/")) {
+    return NextResponse.json(
+      { error: "Unauthorized", message: "Bearer token or API secret required" },
+      { status: 401 }
+    );
+  }
+
+  return NextResponse.redirect(new URL("/login", request.url));
 }
 
 export const config = {


### PR DESCRIPTION
Critical fix: Bearer lc_ tokens were blocked at proxy level, preventing all authenticated agent API access on production.

Changes:
- Bearer lc_ tokens now pass through proxy to per-route auth
- Public paths defined: /login, /api/keys, /api/stats, /api/search, /api/projects, etc
- Session cookie HMAC verification for browser login
- API routes return 401 JSON, browser routes redirect to /login
- .env*.local gitignored