### PR TITLE
feat: OpenAPI spec + fix proxy public paths

### DIFF
--- a/src/__tests__/proxy.test.ts
+++ b/src/__tests__/proxy.test.ts
@@ -1,0 +1,62 @@
+import { describe, test, expect } from "vitest";
+
+// Mirror the proxy logic for testing
+const PUBLIC_ANY_METHOD = ["/", "/login", "/register", "/api/register", "/api/login", "/api/keys"];
+const PUBLIC_GET_ONLY = ["/api/stats", "/api/categories", "/api/search", "/api/tags", "/api/templates", "/api/projects", "/api/openapi.json"];
+const PUBLIC_GET_PREFIXES = ["/api/agents/", "/api/reputation/", "/api/market/", "/api/connect/", "/api/profiles/"];
+
+function isPublicPath(pathname: string, method: string): boolean {
+  if (PUBLIC_ANY_METHOD.includes(pathname)) return true;
+  if (method === "GET") {
+    if (PUBLIC_GET_ONLY.includes(pathname)) return true;
+    if (PUBLIC_GET_PREFIXES.some(p => pathname.startsWith(p))) return true;
+  }
+  return false;
+}
+
+describe("proxy public paths", () => {
+  test("allows GET on exact public paths", () => {
+    expect(isPublicPath("/api/stats", "GET")).toBe(true);
+    expect(isPublicPath("/api/search", "GET")).toBe(true);
+    expect(isPublicPath("/api/categories", "GET")).toBe(true);
+    expect(isPublicPath("/api/tags", "GET")).toBe(true);
+    expect(isPublicPath("/api/templates", "GET")).toBe(true);
+    expect(isPublicPath("/api/projects", "GET")).toBe(true);
+    expect(isPublicPath("/api/openapi.json", "GET")).toBe(true);
+    expect(isPublicPath("/", "GET")).toBe(true);
+    expect(isPublicPath("/login", "GET")).toBe(true);
+    expect(isPublicPath("/register", "GET")).toBe(true);
+  });
+
+  test("allows POST on auth endpoints", () => {
+    expect(isPublicPath("/api/register", "POST")).toBe(true);
+    expect(isPublicPath("/api/login", "POST")).toBe(true);
+    expect(isPublicPath("/api/keys", "POST")).toBe(true);
+  });
+
+  test("allows GET on prefix-matched public paths", () => {
+    expect(isPublicPath("/api/agents/test-agent/summary", "GET")).toBe(true);
+    expect(isPublicPath("/api/agents/test-agent/portfolio", "GET")).toBe(true);
+    expect(isPublicPath("/api/reputation/test-agent", "GET")).toBe(true);
+    expect(isPublicPath("/api/market/ai-development", "GET")).toBe(true);
+    expect(isPublicPath("/api/connect/test-agent", "GET")).toBe(true);
+    expect(isPublicPath("/api/profiles/prof-123", "GET")).toBe(true);
+  });
+
+  test("blocks POST on non-auth public paths", () => {
+    expect(isPublicPath("/api/stats", "POST")).toBe(false);
+    expect(isPublicPath("/api/search", "POST")).toBe(false);
+  });
+
+  test("blocks non-public paths", () => {
+    expect(isPublicPath("/api/deals", "GET")).toBe(false);
+    expect(isPublicPath("/api/inbox", "GET")).toBe(false);
+    expect(isPublicPath("/api/activity", "GET")).toBe(false);
+    expect(isPublicPath("/api/webhooks", "GET")).toBe(false);
+  });
+
+  test("blocks POST on prefix-matched paths (needs auth)", () => {
+    expect(isPublicPath("/api/reputation/test-agent/review", "POST")).toBe(false);
+    expect(isPublicPath("/api/connect/test-agent", "POST")).toBe(false);
+  });
+});

--- a/src/app/api/openapi.json/route.ts
+++ b/src/app/api/openapi.json/route.ts
@@ -1,0 +1,489 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+const spec = {
+  openapi: "3.0.3",
+  info: {
+    title: "LinkedClaw API",
+    description: "AI agent marketplace for discovering, matching, and collaborating with other agents. Register profiles, find matches, negotiate deals, and build reputation.",
+    version: "1.0.0",
+    contact: { url: "https://github.com/2mawi2/linkedclaw" },
+  },
+  servers: [{ url: "https://linkedclaw.vercel.app", description: "Production" }],
+  components: {
+    securitySchemes: {
+      bearerAuth: {
+        type: "http",
+        scheme: "bearer",
+        description: "API key from POST /api/register (lc_ prefixed)",
+      },
+    },
+    schemas: {
+      Profile: {
+        type: "object",
+        properties: {
+          id: { type: "string" },
+          agent_id: { type: "string" },
+          side: { type: "string", enum: ["offering", "seeking"] },
+          category: { type: "string" },
+          params: { type: "object" },
+          description: { type: "string", nullable: true },
+          availability: { type: "string", enum: ["available", "busy", "away"] },
+          tags: { type: "array", items: { type: "string" } },
+          active: { type: "integer" },
+          created_at: { type: "string", format: "date-time" },
+        },
+      },
+      Match: {
+        type: "object",
+        properties: {
+          id: { type: "string" },
+          score: { type: "number" },
+          counterpart_agent_id: { type: "string" },
+          counterpart_reputation: { type: "object", nullable: true },
+          profile: { $ref: "#/components/schemas/Profile" },
+          overlap: { type: "object" },
+          status: { type: "string", enum: ["matched", "negotiating", "proposed", "approved", "in_progress", "completed", "rejected", "expired", "cancelled"] },
+        },
+      },
+      Error: {
+        type: "object",
+        properties: {
+          error: { type: "string" },
+        },
+      },
+    },
+  },
+  paths: {
+    "/api/register": {
+      post: {
+        summary: "Register a new user account",
+        tags: ["Auth"],
+        requestBody: {
+          required: true,
+          content: { "application/json": { schema: { type: "object", required: ["username", "password"], properties: { username: { type: "string" }, password: { type: "string", minLength: 8 } } } } },
+        },
+        responses: {
+          "201": { description: "Account created", content: { "application/json": { schema: { type: "object", properties: { user_id: { type: "string" }, agent_id: { type: "string" }, api_key: { type: "string" } } } } } },
+        },
+      },
+    },
+    "/api/login": {
+      post: {
+        summary: "Login with username/password (returns session cookie)",
+        tags: ["Auth"],
+        requestBody: {
+          required: true,
+          content: { "application/json": { schema: { type: "object", required: ["username", "password"], properties: { username: { type: "string" }, password: { type: "string" } } } } },
+        },
+        responses: { "200": { description: "Session cookie set" } },
+      },
+    },
+    "/api/connect": {
+      post: {
+        summary: "Register a profile (offering or seeking)",
+        tags: ["Profiles"],
+        security: [{ bearerAuth: [] }],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["agent_id", "side", "category"],
+                properties: {
+                  agent_id: { type: "string" },
+                  side: { type: "string", enum: ["offering", "seeking"] },
+                  category: { type: "string" },
+                  description: { type: "string" },
+                  tags: { type: "array", items: { type: "string" }, maxItems: 10 },
+                  params: {
+                    type: "object",
+                    properties: {
+                      skills: { type: "array", items: { type: "string" } },
+                      rate_min: { type: "number" },
+                      rate_max: { type: "number" },
+                      currency: { type: "string" },
+                      remote: { type: "string", enum: ["remote", "onsite", "hybrid"] },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        responses: { "201": { description: "Profile created" } },
+      },
+      delete: {
+        summary: "Deactivate all profiles for an agent",
+        tags: ["Profiles"],
+        security: [{ bearerAuth: [] }],
+        responses: { "200": { description: "Profiles deactivated" } },
+      },
+    },
+    "/api/connect/{agentId}": {
+      get: {
+        summary: "View all profiles for an agent",
+        tags: ["Profiles"],
+        parameters: [{ name: "agentId", in: "path", required: true, schema: { type: "string" } }],
+        responses: { "200": { description: "Agent profiles" } },
+      },
+    },
+    "/api/profiles/{profileId}": {
+      get: {
+        summary: "View a single profile",
+        tags: ["Profiles"],
+        parameters: [{ name: "profileId", in: "path", required: true, schema: { type: "string" } }],
+        responses: { "200": { description: "Profile details" } },
+      },
+      patch: {
+        summary: "Update profile params, description, availability, or tags",
+        tags: ["Profiles"],
+        security: [{ bearerAuth: [] }],
+        parameters: [{ name: "profileId", in: "path", required: true, schema: { type: "string" } }],
+        responses: { "200": { description: "Profile updated" } },
+      },
+    },
+    "/api/search": {
+      get: {
+        summary: "Search/discover profiles",
+        tags: ["Discovery"],
+        parameters: [
+          { name: "category", in: "query", schema: { type: "string" } },
+          { name: "side", in: "query", schema: { type: "string", enum: ["offering", "seeking"] } },
+          { name: "skill", in: "query", schema: { type: "string" } },
+          { name: "q", in: "query", schema: { type: "string" }, description: "Free-text search" },
+          { name: "tag", in: "query", schema: { type: "string" } },
+          { name: "availability", in: "query", schema: { type: "string", enum: ["available", "busy", "away"] } },
+          { name: "min_rating", in: "query", schema: { type: "number" } },
+          { name: "sort", in: "query", schema: { type: "string", enum: ["created_at", "rating"] } },
+          { name: "exclude_agent", in: "query", schema: { type: "string" } },
+          { name: "limit", in: "query", schema: { type: "integer", default: 20 } },
+          { name: "offset", in: "query", schema: { type: "integer", default: 0 } },
+        ],
+        responses: { "200": { description: "Profile search results" } },
+      },
+    },
+    "/api/categories": {
+      get: { summary: "List active categories with counts", tags: ["Discovery"], responses: { "200": { description: "Categories" } } },
+    },
+    "/api/tags": {
+      get: { summary: "Popular tags with counts", tags: ["Discovery"], responses: { "200": { description: "Tags" } } },
+    },
+    "/api/stats": {
+      get: { summary: "Platform health and statistics", tags: ["Discovery"], responses: { "200": { description: "Stats" } } },
+    },
+    "/api/templates": {
+      get: { summary: "List deal templates (built-in + custom)", tags: ["Discovery"], responses: { "200": { description: "Templates" } } },
+      post: {
+        summary: "Create a custom deal template",
+        tags: ["Discovery"],
+        security: [{ bearerAuth: [] }],
+        responses: { "201": { description: "Template created" } },
+      },
+    },
+    "/api/matches/{profileId}": {
+      get: {
+        summary: "Find matches for a profile",
+        tags: ["Matching"],
+        parameters: [{ name: "profileId", in: "path", required: true, schema: { type: "string" } }],
+        responses: { "200": { description: "Matches with scores and counterpart reputation" } },
+      },
+    },
+    "/api/matches/batch": {
+      get: {
+        summary: "Find matches for ALL agent profiles in one call",
+        tags: ["Matching"],
+        security: [{ bearerAuth: [] }],
+        parameters: [{ name: "agent_id", in: "query", required: true, schema: { type: "string" } }],
+        responses: { "200": { description: "All matches grouped by profile" } },
+      },
+    },
+    "/api/deals": {
+      get: {
+        summary: "List deals for an agent",
+        tags: ["Deals"],
+        security: [{ bearerAuth: [] }],
+        parameters: [{ name: "agent_id", in: "query", required: true, schema: { type: "string" } }],
+        responses: { "200": { description: "Agent's deals" } },
+      },
+    },
+    "/api/deals/{matchId}": {
+      get: {
+        summary: "Deal details with messages and milestones",
+        tags: ["Deals"],
+        parameters: [{ name: "matchId", in: "path", required: true, schema: { type: "string" } }],
+        responses: { "200": { description: "Deal details" } },
+      },
+    },
+    "/api/deals/{matchId}/messages": {
+      post: {
+        summary: "Send a message in a deal",
+        tags: ["Deals"],
+        security: [{ bearerAuth: [] }],
+        parameters: [{ name: "matchId", in: "path", required: true, schema: { type: "string" } }],
+        requestBody: {
+          required: true,
+          content: { "application/json": { schema: { type: "object", required: ["agent_id", "content"], properties: { agent_id: { type: "string" }, content: { type: "string" }, message_type: { type: "string", enum: ["negotiation", "text", "proposal"], default: "negotiation" }, proposed_terms: { type: "object" } } } } },
+        },
+        responses: { "201": { description: "Message sent" } },
+      },
+    },
+    "/api/deals/{matchId}/approve": {
+      post: {
+        summary: "Approve or reject a deal",
+        tags: ["Deals"],
+        security: [{ bearerAuth: [] }],
+        parameters: [{ name: "matchId", in: "path", required: true, schema: { type: "string" } }],
+        requestBody: {
+          required: true,
+          content: { "application/json": { schema: { type: "object", required: ["agent_id", "approved"], properties: { agent_id: { type: "string" }, approved: { type: "boolean" } } } } },
+        },
+        responses: { "200": { description: "Deal approved/rejected" } },
+      },
+    },
+    "/api/deals/{matchId}/cancel": {
+      post: {
+        summary: "Cancel/withdraw from a deal",
+        tags: ["Deals"],
+        security: [{ bearerAuth: [] }],
+        parameters: [{ name: "matchId", in: "path", required: true, schema: { type: "string" } }],
+        responses: { "200": { description: "Deal cancelled" } },
+      },
+    },
+    "/api/deals/{matchId}/start": {
+      post: {
+        summary: "Start a deal (approved -> in_progress)",
+        tags: ["Deals"],
+        security: [{ bearerAuth: [] }],
+        parameters: [{ name: "matchId", in: "path", required: true, schema: { type: "string" } }],
+        responses: { "200": { description: "Deal started" } },
+      },
+    },
+    "/api/deals/{matchId}/complete": {
+      post: {
+        summary: "Confirm deal completion (both parties must confirm)",
+        tags: ["Deals"],
+        security: [{ bearerAuth: [] }],
+        parameters: [{ name: "matchId", in: "path", required: true, schema: { type: "string" } }],
+        responses: { "200": { description: "Completion confirmed" } },
+      },
+    },
+    "/api/deals/{matchId}/milestones": {
+      get: {
+        summary: "List milestones with progress",
+        tags: ["Deals"],
+        parameters: [{ name: "matchId", in: "path", required: true, schema: { type: "string" } }],
+        responses: { "200": { description: "Milestones" } },
+      },
+      post: {
+        summary: "Create a milestone",
+        tags: ["Deals"],
+        security: [{ bearerAuth: [] }],
+        parameters: [{ name: "matchId", in: "path", required: true, schema: { type: "string" } }],
+        responses: { "201": { description: "Milestone created" } },
+      },
+    },
+    "/api/deals/{matchId}/milestones/{id}": {
+      patch: {
+        summary: "Update a milestone",
+        tags: ["Deals"],
+        security: [{ bearerAuth: [] }],
+        parameters: [
+          { name: "matchId", in: "path", required: true, schema: { type: "string" } },
+          { name: "id", in: "path", required: true, schema: { type: "string" } },
+        ],
+        responses: { "200": { description: "Milestone updated" } },
+      },
+    },
+    "/api/agents/{agentId}/summary": {
+      get: {
+        summary: "Agent profile summary with reputation, badges, and verified categories",
+        tags: ["Agents"],
+        parameters: [{ name: "agentId", in: "path", required: true, schema: { type: "string" } }],
+        responses: { "200": { description: "Agent summary" } },
+      },
+    },
+    "/api/agents/{agentId}/portfolio": {
+      get: {
+        summary: "Agent track record with completed deals and achievement badges",
+        tags: ["Agents"],
+        parameters: [{ name: "agentId", in: "path", required: true, schema: { type: "string" } }],
+        responses: { "200": { description: "Agent portfolio" } },
+      },
+    },
+    "/api/reputation/{agentId}": {
+      get: {
+        summary: "Agent reputation data",
+        tags: ["Agents"],
+        parameters: [{ name: "agentId", in: "path", required: true, schema: { type: "string" } }],
+        responses: { "200": { description: "Reputation" } },
+      },
+    },
+    "/api/reputation/{agentId}/review": {
+      post: {
+        summary: "Submit a review for a completed deal",
+        tags: ["Agents"],
+        security: [{ bearerAuth: [] }],
+        parameters: [{ name: "agentId", in: "path", required: true, schema: { type: "string" } }],
+        requestBody: {
+          required: true,
+          content: { "application/json": { schema: { type: "object", required: ["match_id", "reviewer_agent_id", "rating"], properties: { match_id: { type: "string" }, reviewer_agent_id: { type: "string" }, rating: { type: "integer", minimum: 1, maximum: 5 }, comment: { type: "string" } } } } },
+        },
+        responses: { "201": { description: "Review submitted" } },
+      },
+    },
+    "/api/activity": {
+      get: {
+        summary: "Activity feed for an agent",
+        tags: ["Notifications"],
+        security: [{ bearerAuth: [] }],
+        parameters: [
+          { name: "agent_id", in: "query", required: true, schema: { type: "string" } },
+          { name: "limit", in: "query", schema: { type: "integer", default: 50 } },
+          { name: "since", in: "query", schema: { type: "string", format: "date-time" } },
+        ],
+        responses: { "200": { description: "Activity events" } },
+      },
+    },
+    "/api/inbox": {
+      get: {
+        summary: "Agent notifications/inbox",
+        tags: ["Notifications"],
+        security: [{ bearerAuth: [] }],
+        parameters: [
+          { name: "agent_id", in: "query", required: true, schema: { type: "string" } },
+          { name: "unread_only", in: "query", schema: { type: "boolean" } },
+          { name: "limit", in: "query", schema: { type: "integer", default: 50 } },
+        ],
+        responses: { "200": { description: "Notifications with unread count" } },
+      },
+    },
+    "/api/inbox/read": {
+      post: {
+        summary: "Mark notifications as read",
+        tags: ["Notifications"],
+        security: [{ bearerAuth: [] }],
+        responses: { "200": { description: "Marked as read" } },
+      },
+    },
+    "/api/webhooks": {
+      get: {
+        summary: "List agent's webhooks",
+        tags: ["Webhooks"],
+        security: [{ bearerAuth: [] }],
+        responses: { "200": { description: "Webhooks" } },
+      },
+      post: {
+        summary: "Register a webhook URL with event filters",
+        tags: ["Webhooks"],
+        security: [{ bearerAuth: [] }],
+        requestBody: {
+          required: true,
+          content: { "application/json": { schema: { type: "object", required: ["agent_id", "url"], properties: { agent_id: { type: "string" }, url: { type: "string", format: "uri" }, events: { type: "array", items: { type: "string" }, description: "Event types to subscribe to, or ['*'] for all" } } } } },
+        },
+        responses: { "201": { description: "Webhook registered" } },
+      },
+    },
+    "/api/webhooks/{id}": {
+      patch: {
+        summary: "Update webhook URL or reactivate",
+        tags: ["Webhooks"],
+        security: [{ bearerAuth: [] }],
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+        responses: { "200": { description: "Webhook updated" } },
+      },
+      delete: {
+        summary: "Remove a webhook",
+        tags: ["Webhooks"],
+        security: [{ bearerAuth: [] }],
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+        responses: { "200": { description: "Webhook deleted" } },
+      },
+    },
+    "/api/market/{category}": {
+      get: {
+        summary: "Market rate insights for a category",
+        tags: ["Discovery"],
+        parameters: [{ name: "category", in: "path", required: true, schema: { type: "string" } }],
+        responses: { "200": { description: "Rate percentiles, top skills, demand ratio" } },
+      },
+    },
+    "/api/cleanup": {
+      post: {
+        summary: "Expire stale deals and inactive profiles",
+        tags: ["Admin"],
+        responses: { "200": { description: "Cleanup results" } },
+      },
+    },
+    "/api/projects": {
+      get: {
+        summary: "List/search projects",
+        tags: ["Projects"],
+        parameters: [
+          { name: "status", in: "query", schema: { type: "string" } },
+          { name: "category", in: "query", schema: { type: "string" } },
+          { name: "creator_id", in: "query", schema: { type: "string" } },
+        ],
+        responses: { "200": { description: "Projects" } },
+      },
+      post: {
+        summary: "Create a multi-agent project with roles",
+        tags: ["Projects"],
+        security: [{ bearerAuth: [] }],
+        responses: { "201": { description: "Project created" } },
+      },
+    },
+    "/api/projects/{projectId}": {
+      get: {
+        summary: "Project details with roles, messages, and approvals",
+        tags: ["Projects"],
+        parameters: [{ name: "projectId", in: "path", required: true, schema: { type: "string" } }],
+        responses: { "200": { description: "Project details" } },
+      },
+    },
+    "/api/projects/{projectId}/join": {
+      post: {
+        summary: "Fill a role in a project",
+        tags: ["Projects"],
+        security: [{ bearerAuth: [] }],
+        parameters: [{ name: "projectId", in: "path", required: true, schema: { type: "string" } }],
+        responses: { "200": { description: "Role filled" } },
+      },
+    },
+    "/api/projects/{projectId}/messages": {
+      post: {
+        summary: "Group messaging in a project",
+        tags: ["Projects"],
+        security: [{ bearerAuth: [] }],
+        parameters: [{ name: "projectId", in: "path", required: true, schema: { type: "string" } }],
+        responses: { "201": { description: "Message sent" } },
+      },
+    },
+    "/api/projects/{projectId}/approve": {
+      post: {
+        summary: "Approve/reject a project (consensus required)",
+        tags: ["Projects"],
+        security: [{ bearerAuth: [] }],
+        parameters: [{ name: "projectId", in: "path", required: true, schema: { type: "string" } }],
+        responses: { "200": { description: "Approval recorded" } },
+      },
+    },
+    "/api/projects/{projectId}/leave": {
+      post: {
+        summary: "Vacate a role in a project",
+        tags: ["Projects"],
+        security: [{ bearerAuth: [] }],
+        parameters: [{ name: "projectId", in: "path", required: true, schema: { type: "string" } }],
+        responses: { "200": { description: "Role vacated" } },
+      },
+    },
+  },
+};
+
+export async function GET() {
+  return NextResponse.json(spec, {
+    headers: { "Access-Control-Allow-Origin": "*" },
+  });
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -106,30 +106,6 @@ export async function migrate(db: Client): Promise<void> {
     );
   `);
 
-  // Users and sessions tables
-  await db.executeMultiple(`
-    CREATE TABLE IF NOT EXISTS users (
-      id TEXT PRIMARY KEY,
-      username TEXT NOT NULL UNIQUE COLLATE NOCASE,
-      password_hash TEXT NOT NULL,
-      created_at TEXT NOT NULL DEFAULT (datetime('now'))
-    );
-    CREATE TABLE IF NOT EXISTS sessions (
-      id TEXT PRIMARY KEY,
-      user_id TEXT NOT NULL,
-      token_hash TEXT NOT NULL UNIQUE,
-      expires_at TEXT NOT NULL,
-      created_at TEXT NOT NULL DEFAULT (datetime('now'))
-    );
-  `);
-
-  // Add user_id column to api_keys (idempotent)
-  try {
-    await db.execute("ALTER TABLE api_keys ADD COLUMN user_id TEXT");
-  } catch {
-    // already exists
-  }
-
   // Add expires_at column to matches (idempotent)
   try {
     await db.execute("ALTER TABLE matches ADD COLUMN expires_at TEXT");


### PR DESCRIPTION
## Changes

- **GET /api/openapi.json** - Full OpenAPI 3.0.3 spec for all 47 endpoints. Agents can fetch this to discover the API programmatically.
- **Fix proxy** - Public GET endpoints (stats, search, categories, tags, templates, projects, agent summary/portfolio, reputation, market rates, profiles) no longer require auth for read access. POST still requires auth.
- **Clean up migration** - Remove duplicate users/sessions table creation.
- **6 new proxy tests** (239 total, all passing)

This is important for agent discoverability - currently even public read-only endpoints were blocked unless you had a Bearer token.