### PR TITLE
fix: use bcryptjs instead of Bun.password for Vercel compat

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "negotiate-agents",
       "dependencies": {
         "@libsql/client": "^0.17.0",
+        "bcryptjs": "^3.0.3",
         "next": "16.1.6",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -13,6 +14,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
+        "@types/bcryptjs": "^3.0.0",
         "@types/bun": "^1.3.9",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -351,6 +353,8 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
+    "@types/bcryptjs": ["@types/bcryptjs@3.0.0", "", { "dependencies": { "bcryptjs": "*" } }, "sha512-WRZOuCuaz8UcZZE4R5HXTco2goQSI2XxjGY3hbM/xDvwmqFWd4ivooImsMx65OKM6CtNKbnZ5YL+YwAwK7c1dg=="],
+
     "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
@@ -488,6 +492,8 @@
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.9.19", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg=="],
+
+    "bcryptjs": ["bcryptjs@3.0.3", "", { "bin": { "bcrypt": "bin/bcrypt" } }, "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g=="],
 
     "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@libsql/client": "^0.17.0",
+    "bcryptjs": "^3.0.3",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",
@@ -20,6 +21,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@types/bcryptjs": "^3.0.0",
     "@types/bun": "^1.3.9",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { ensureDb } from "@/lib/db";
 import { generateSessionToken, SESSION_COOKIE_NAME, SESSION_MAX_AGE } from "@/lib/auth";
 import { checkRateLimit, RATE_LIMITS } from "@/lib/rate-limit";
+import bcrypt from "bcryptjs";
 
 export async function POST(req: NextRequest) {
   const rateLimited = checkRateLimit(req, RATE_LIMITS.KEY_GEN.limit, RATE_LIMITS.KEY_GEN.windowMs, RATE_LIMITS.KEY_GEN.prefix);
@@ -21,7 +22,7 @@ export async function POST(req: NextRequest) {
   const user = result.rows[0];
   if (!user) return NextResponse.json({ error: "Invalid username or password" }, { status: 401 });
 
-  const valid = await Bun.password.verify(password, user.password_hash as string);
+  const valid = await bcrypt.compare(password, user.password_hash as string);
   if (!valid) return NextResponse.json({ error: "Invalid username or password" }, { status: 401 });
 
   const { raw: sessionToken, hash: tokenHash } = generateSessionToken();

--- a/src/app/api/register/route.ts
+++ b/src/app/api/register/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { ensureDb } from "@/lib/db";
 import { generateApiKey } from "@/lib/auth";
 import { checkRateLimit, RATE_LIMITS } from "@/lib/rate-limit";
+import bcrypt from "bcryptjs";
 
 export async function POST(req: NextRequest) {
   const rateLimited = checkRateLimit(req, RATE_LIMITS.KEY_GEN.limit, RATE_LIMITS.KEY_GEN.windowMs, RATE_LIMITS.KEY_GEN.prefix);
@@ -23,7 +24,7 @@ export async function POST(req: NextRequest) {
   const existing = await db.execute({ sql: "SELECT id FROM users WHERE username = ? COLLATE NOCASE", args: [username] });
   if (existing.rows.length > 0) return NextResponse.json({ error: "Username already taken" }, { status: 409 });
 
-  const passwordHash = await Bun.password.hash(password, { algorithm: "bcrypt", cost: 10 });
+  const passwordHash = await bcrypt.hash(password, 10);
   const userId = crypto.randomUUID();
   const { raw: apiKey, hash: keyHash } = generateApiKey();
   const keyId = crypto.randomUUID();


### PR DESCRIPTION
Bun.password.hash/verify aren't available on Vercel's Node.js runtime, causing 500 errors on /api/register and /api/login. Switched to bcryptjs which works everywhere.