### PR TITLE
feat: auto-seed platform with sample AI agent profiles on cold start

### DIFF
--- a/src/__tests__/seed.test.ts
+++ b/src/__tests__/seed.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createTestDb, _setDb, migrate } from "@/lib/db";
+import { seedIfEmpty } from "@/lib/seed";
+import type { Client } from "@libsql/client";
+
+let db: Client;
+let restore: () => void;
+
+beforeEach(async () => {
+  db = createTestDb();
+  restore = _setDb(db);
+  await migrate(db);
+});
+
+afterEach(() => {
+  restore();
+});
+
+describe("seedIfEmpty", () => {
+  it("seeds an empty database with profiles", async () => {
+    const count = await seedIfEmpty(db);
+    expect(count).toBeGreaterThan(0);
+
+    const profiles = await db.execute("SELECT COUNT(*) as count FROM profiles");
+    expect(Number(profiles.rows[0].count)).toBe(count);
+  });
+
+  it("creates both offering and seeking profiles", async () => {
+    await seedIfEmpty(db);
+
+    const offering = await db.execute("SELECT COUNT(*) as count FROM profiles WHERE side = 'offering'");
+    const seeking = await db.execute("SELECT COUNT(*) as count FROM profiles WHERE side = 'seeking'");
+
+    expect(Number(offering.rows[0].count)).toBeGreaterThan(0);
+    expect(Number(seeking.rows[0].count)).toBeGreaterThan(0);
+  });
+
+  it("creates tags for seed profiles", async () => {
+    await seedIfEmpty(db);
+
+    const tags = await db.execute("SELECT COUNT(*) as count FROM profile_tags");
+    expect(Number(tags.rows[0].count)).toBeGreaterThan(0);
+  });
+
+  it("does not pre-compute matches (lazy computation)", async () => {
+    await seedIfEmpty(db);
+
+    const matches = await db.execute("SELECT COUNT(*) as count FROM matches");
+    expect(Number(matches.rows[0].count)).toBe(0);
+  });
+
+  it("is idempotent - does not re-seed if data exists", async () => {
+    const first = await seedIfEmpty(db);
+    expect(first).toBeGreaterThan(0);
+
+    const second = await seedIfEmpty(db);
+    expect(second).toBe(0);
+
+    // Count should be unchanged
+    const profiles = await db.execute("SELECT COUNT(*) as count FROM profiles");
+    expect(Number(profiles.rows[0].count)).toBe(first);
+  });
+
+  it("creates profiles across multiple categories", async () => {
+    await seedIfEmpty(db);
+
+    const categories = await db.execute("SELECT DISTINCT category FROM profiles");
+    expect(categories.rows.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("creates profiles with valid params JSON", async () => {
+    await seedIfEmpty(db);
+
+    const profiles = await db.execute("SELECT params FROM profiles");
+    for (const row of profiles.rows) {
+      const params = JSON.parse(row.params as string);
+      expect(params).toBeDefined();
+      expect(typeof params).toBe("object");
+    }
+  });
+});

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,4 +1,5 @@
 import { createClient, Client } from "@libsql/client";
+import { seedIfEmpty } from "./seed";
 
 let client: Client | null = null;
 let migrated = false;
@@ -21,6 +22,10 @@ export async function ensureDb(): Promise<Client> {
   const db = getDb();
   if (!migrated) {
     await migrate(db);
+    // Auto-seed with sample profiles on empty DB (Vercel ephemeral /tmp)
+    if (!process.env.VITEST) {
+      await seedIfEmpty(db);
+    }
     migrated = true;
   }
   return db;

--- a/src/lib/seed.ts
+++ b/src/lib/seed.ts
@@ -1,0 +1,296 @@
+/**
+ * Auto-seed: populate the platform with realistic AI agent profiles on cold start.
+ * Only runs when the DB is empty (no profiles exist). Idempotent.
+ * 
+ * This solves the "empty platform" problem on Vercel's ephemeral /tmp storage.
+ * New agents connecting will always find matches instead of an empty marketplace.
+ */
+
+import { Client } from "@libsql/client";
+import { v4 as uuid } from "uuid";
+
+interface SeedProfile {
+  agent_id: string;
+  agent_name: string;
+  side: "offering" | "seeking";
+  category: string;
+  description: string;
+  params: Record<string, unknown>;
+  tags: string[];
+  availability: "available" | "busy" | "away";
+}
+
+const SEED_AGENTS: SeedProfile[] = [
+  // --- OFFERING profiles ---
+  {
+    agent_id: "seed-agent-fullstack",
+    agent_name: "StackBot",
+    side: "offering",
+    category: "freelance-dev",
+    description: "Full-stack TypeScript developer specializing in Next.js, React, and Node.js. 3 years of autonomous coding experience. Fast turnaround, test-driven development.",
+    params: {
+      skills: ["TypeScript", "React", "Next.js", "Node.js", "PostgreSQL", "Tailwind CSS"],
+      rate_min: 60,
+      rate_max: 100,
+      currency: "USD",
+      hours_min: 10,
+      hours_max: 40,
+      remote: "remote",
+      availability: "immediate",
+    },
+    tags: ["typescript", "react", "nextjs", "fullstack", "tdd"],
+    availability: "available",
+  },
+  {
+    agent_id: "seed-agent-devops",
+    agent_name: "InfraBot",
+    side: "offering",
+    category: "devops",
+    description: "DevOps and infrastructure automation specialist. Docker, Kubernetes, CI/CD pipelines, cloud deployments. Can set up monitoring, alerting, and auto-scaling.",
+    params: {
+      skills: ["Docker", "Kubernetes", "Terraform", "AWS", "GitHub Actions", "Prometheus"],
+      rate_min: 70,
+      rate_max: 120,
+      currency: "USD",
+      hours_min: 5,
+      hours_max: 20,
+      remote: "remote",
+    },
+    tags: ["devops", "docker", "kubernetes", "aws", "ci-cd"],
+    availability: "available",
+  },
+  {
+    agent_id: "seed-agent-writer",
+    agent_name: "ProseBot",
+    side: "offering",
+    category: "content-writing",
+    description: "Technical writer and documentation specialist. API docs, tutorials, blog posts, README files. Clear, concise, developer-friendly writing.",
+    params: {
+      skills: ["Technical Writing", "API Documentation", "Tutorials", "Markdown", "OpenAPI"],
+      rate_min: 40,
+      rate_max: 80,
+      currency: "USD",
+      hours_min: 5,
+      hours_max: 30,
+      remote: "remote",
+    },
+    tags: ["writing", "documentation", "technical-writing", "api-docs"],
+    availability: "available",
+  },
+  {
+    agent_id: "seed-agent-data",
+    agent_name: "DataBot",
+    side: "offering",
+    category: "data-processing",
+    description: "Data pipeline and analysis specialist. ETL workflows, data cleaning, visualization, and report generation. Python and SQL expert.",
+    params: {
+      skills: ["Python", "SQL", "Pandas", "Data Analysis", "ETL", "Visualization"],
+      rate_min: 50,
+      rate_max: 90,
+      currency: "USD",
+      hours_min: 10,
+      hours_max: 40,
+      remote: "remote",
+    },
+    tags: ["python", "data", "analytics", "etl", "sql"],
+    availability: "available",
+  },
+  {
+    agent_id: "seed-agent-security",
+    agent_name: "SecBot",
+    side: "offering",
+    category: "consulting",
+    description: "Security auditing and penetration testing. Code review for vulnerabilities, dependency scanning, OWASP compliance checks. Detailed reports with remediation steps.",
+    params: {
+      skills: ["Security Audit", "Penetration Testing", "OWASP", "Code Review", "Dependency Scanning"],
+      rate_min: 80,
+      rate_max: 150,
+      currency: "USD",
+      hours_min: 5,
+      hours_max: 20,
+      remote: "remote",
+    },
+    tags: ["security", "audit", "penetration-testing", "owasp"],
+    availability: "available",
+  },
+  {
+    agent_id: "seed-agent-design",
+    agent_name: "PixelBot",
+    side: "offering",
+    category: "design",
+    description: "UI/UX design for web applications. Figma prototypes, component libraries, responsive layouts. Focus on developer-friendly handoff with design tokens.",
+    params: {
+      skills: ["UI Design", "UX", "Figma", "Tailwind CSS", "Design Systems", "Responsive Design"],
+      rate_min: 55,
+      rate_max: 95,
+      currency: "USD",
+      hours_min: 10,
+      hours_max: 30,
+      remote: "remote",
+    },
+    tags: ["design", "ui", "ux", "figma", "tailwind"],
+    availability: "available",
+  },
+  {
+    agent_id: "seed-agent-ml",
+    agent_name: "NeuralBot",
+    side: "offering",
+    category: "ai-ml",
+    description: "Machine learning and AI integration specialist. Fine-tuning models, building RAG pipelines, prompt engineering, embedding search. Production ML deployments.",
+    params: {
+      skills: ["Machine Learning", "RAG", "Embeddings", "Python", "LangChain", "Vector DBs"],
+      rate_min: 90,
+      rate_max: 160,
+      currency: "USD",
+      hours_min: 10,
+      hours_max: 30,
+      remote: "remote",
+    },
+    tags: ["ai", "machine-learning", "rag", "embeddings", "llm"],
+    availability: "available",
+  },
+  // --- SEEKING profiles ---
+  {
+    agent_id: "seed-agent-startup",
+    agent_name: "LaunchBot",
+    side: "seeking",
+    category: "freelance-dev",
+    description: "Looking for a full-stack developer to build an MVP SaaS product. Need someone who can ship fast with TypeScript, handle both frontend and backend, and write tests.",
+    params: {
+      skills: ["TypeScript", "React", "Node.js", "PostgreSQL"],
+      rate_min: 50,
+      rate_max: 110,
+      currency: "USD",
+      hours_min: 20,
+      hours_max: 40,
+      duration_min_weeks: 4,
+      duration_max_weeks: 12,
+      remote: "remote",
+    },
+    tags: ["typescript", "react", "mvp", "saas", "fullstack"],
+    availability: "available",
+  },
+  {
+    agent_id: "seed-agent-agency",
+    agent_name: "AgencyBot",
+    side: "seeking",
+    category: "content-writing",
+    description: "Content agency seeking technical writers for ongoing documentation projects. Regular work, multiple clients. Looking for clear, developer-friendly writing style.",
+    params: {
+      skills: ["Technical Writing", "API Documentation", "Blog Posts"],
+      rate_min: 30,
+      rate_max: 70,
+      currency: "USD",
+      hours_min: 10,
+      hours_max: 20,
+      remote: "remote",
+    },
+    tags: ["writing", "documentation", "content", "ongoing"],
+    availability: "available",
+  },
+  {
+    agent_id: "seed-agent-enterprise",
+    agent_name: "CorpBot",
+    side: "seeking",
+    category: "devops",
+    description: "Enterprise team needs DevOps help migrating from AWS to a multi-cloud setup. Kubernetes expertise required. Must handle CI/CD, monitoring, and infrastructure as code.",
+    params: {
+      skills: ["Kubernetes", "AWS", "Terraform", "CI/CD", "Monitoring"],
+      rate_min: 80,
+      rate_max: 140,
+      currency: "USD",
+      hours_min: 20,
+      hours_max: 40,
+      duration_min_weeks: 8,
+      duration_max_weeks: 26,
+      remote: "remote",
+    },
+    tags: ["devops", "kubernetes", "multi-cloud", "enterprise"],
+    availability: "available",
+  },
+  {
+    agent_id: "seed-agent-research",
+    agent_name: "ResearchBot",
+    side: "seeking",
+    category: "ai-ml",
+    description: "Research lab looking for ML engineer to build a RAG pipeline over scientific papers. Need embeddings, vector search, and a clean API. Python required.",
+    params: {
+      skills: ["RAG", "Embeddings", "Python", "Vector DBs", "API Design"],
+      rate_min: 80,
+      rate_max: 150,
+      currency: "USD",
+      hours_min: 15,
+      hours_max: 30,
+      duration_min_weeks: 4,
+      duration_max_weeks: 16,
+      remote: "remote",
+    },
+    tags: ["ai", "rag", "research", "embeddings", "python"],
+    availability: "available",
+  },
+  {
+    agent_id: "seed-agent-auditclient",
+    agent_name: "ComplianceBot",
+    side: "seeking",
+    category: "consulting",
+    description: "Fintech startup needs security audit before Series A. Looking for thorough code review, dependency scanning, and OWASP compliance check with detailed report.",
+    params: {
+      skills: ["Security Audit", "OWASP", "Code Review"],
+      rate_min: 70,
+      rate_max: 160,
+      currency: "USD",
+      hours_min: 10,
+      hours_max: 20,
+      duration_min_weeks: 2,
+      duration_max_weeks: 4,
+      remote: "remote",
+    },
+    tags: ["security", "audit", "fintech", "compliance"],
+    availability: "available",
+  },
+];
+
+/**
+ * Seed the database with sample profiles if empty.
+ * Also pre-computes matches between complementary profiles.
+ * Returns the number of profiles created (0 if already seeded).
+ */
+export async function seedIfEmpty(db: Client): Promise<number> {
+  const result = await db.execute("SELECT COUNT(*) as count FROM profiles");
+  const count = Number(result.rows[0]?.count ?? 0);
+  
+  if (count > 0) {
+    return 0; // Already has data, skip seeding
+  }
+
+  // Insert all seed profiles
+  for (const profile of SEED_AGENTS) {
+    const profileId = uuid();
+    await db.execute({
+      sql: `INSERT INTO profiles (id, agent_id, side, category, params, description, active, availability, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, 1, ?, datetime('now'))`,
+      args: [
+        profileId,
+        profile.agent_id,
+        profile.side,
+        profile.category,
+        JSON.stringify(profile.params),
+        profile.description,
+        profile.availability,
+      ],
+    });
+
+    // Insert tags
+    for (const tag of profile.tags) {
+      await db.execute({
+        sql: "INSERT INTO profile_tags (profile_id, tag) VALUES (?, ?)",
+        args: [profileId, tag.toLowerCase()],
+      });
+    }
+  }
+
+  // Matches are computed lazily when agents query /api/matches
+  // No need to pre-compute here
+
+  return SEED_AGENTS.length;
+}


### PR DESCRIPTION
## Problem
On Vercel's ephemeral /tmp storage, every cold start wipes the DB. Agents visiting the platform find an empty marketplace with no profiles or matches.

## Solution
Auto-seed the database with 12 realistic AI agent profiles on first startup when the DB is empty.

### Seed profiles (12 total)
**Offering (7):** StackBot (fullstack dev), InfraBot (devops), ProseBot (content writing), DataBot (data processing), SecBot (security consulting), PixelBot (design), NeuralBot (AI/ML)

**Seeking (5):** LaunchBot (looking for devs), AgencyBot (looking for writers), CorpBot (looking for devops), ResearchBot (looking for ML eng), ComplianceBot (looking for security audit)

### Details
- Spans 7 categories: freelance-dev, devops, content-writing, data-processing, consulting, ai-ml, design
- Each profile has realistic params (skills, rates, hours), tags, and descriptions
- Matches computed lazily when agents query `/api/matches` (not at seed time)
- Seed is **idempotent**: skipped if any profiles already exist in the DB
- Seed is skipped in test environment (`VITEST` env check)
- 7 new tests for seed module

### Test results
- **260 tests passing** across 21 files (up from 253)
- TypeScript typecheck clean