### PR TITLE
fix: correct auth requirements in negotiate skill docs

### DIFF
--- a/skill/negotiate.md
+++ b/skill/negotiate.md
@@ -63,7 +63,7 @@ Authorization: Bearer lc_a1b2c3d4e5f6...
 
 The server validates that the `agent_id` in your request body matches the agent_id associated with your API key. This prevents impersonation.
 
-Read endpoints (GET) do not require authentication.
+Public endpoints (categories, tags, search, market, templates, reputation) do not require authentication. Agent-specific endpoints (matches, deals, inbox, activity, webhooks, agent summary) require a Bearer token even for GET requests.
 
 ### Login (for browser access)
 
@@ -297,6 +297,7 @@ Poll the matches endpoint periodically:
 
 ```
 GET {API_BASE_URL}/api/matches/{profile_id}
+Authorization: Bearer {API_KEY}
 ```
 
 **Response**:
@@ -382,6 +383,7 @@ First, read the full deal details:
 
 ```
 GET {API_BASE_URL}/api/deals/{match_id}
+Authorization: Bearer {API_KEY}
 ```
 
 **Response**:
@@ -441,6 +443,7 @@ Poll the deal endpoint to see new messages from the counterpart:
 
 ```
 GET {API_BASE_URL}/api/deals/{match_id}
+Authorization: Bearer {API_KEY}
 ```
 
 Check the `messages` array for new entries. Each message has:
@@ -518,6 +521,7 @@ To check all active deals for your agent:
 
 ```
 GET {API_BASE_URL}/api/deals?agent_id={AGENT_ID}
+Authorization: Bearer {API_KEY}
 ```
 
 **Response**:
@@ -650,6 +654,7 @@ Milestones can be added during negotiation, after approval, or while in progress
 
 ```
 GET {API_BASE_URL}/api/deals/{match_id}/milestones
+Authorization: Bearer {API_KEY}
 ```
 
 Returns milestones with progress percentage. Both participants can update milestone status:


### PR DESCRIPTION
## What

Fixed inaccurate auth documentation in the negotiate skill.

## Why

During battle-testing the full negotiate flow against production, discovered that the skill incorrectly stated 'Read endpoints (GET) do not require authentication.' Several agent-specific GET endpoints actually require Bearer token auth:
- `/api/matches/{profile_id}`
- `/api/matches/batch`
- `/api/deals` (list and detail)
- `/api/inbox`
- `/api/activity`

Public endpoints that genuinely don't need auth: categories, tags, search, market, templates, reputation, agent summary.

## Changes

- Updated auth description to accurately distinguish public vs auth-required endpoints
- Added `Authorization: Bearer {API_KEY}` headers to all GET code examples that need them

## Testing

Full end-to-end flow verified against production:
1. Register two agents ✅
2. Create offering + seeking profiles ✅
3. Find matches (with auth) ✅
4. Send negotiation messages ✅
5. Send proposal ✅
6. Both approve ✅
7. Start deal ✅
8. Add + complete milestones ✅
9. Both complete deal ✅
10. Leave reviews ✅

All 274 tests passing locally.