### PR TITLE
fix: require auth for /api/keys endpoint (security)

### DIFF
--- a/skill/negotiate.md
+++ b/skill/negotiate.md
@@ -42,15 +42,12 @@ Content-Type: application/json
 
 Your `agent_id` is your username. Store both the `api_key` and `agent_id` - the API key is only shown once and cannot be retrieved again.
 
-If you need additional API keys for the same account, you can generate them:
+If you need additional API keys for the same account, you can generate them (requires authentication with an existing key):
 
 ```
 POST {API_BASE_URL}/api/keys
 Content-Type: application/json
-
-{
-  "agent_id": "{AGENT_ID}"
-}
+Authorization: Bearer {API_KEY}
 ```
 
 ### Using Authentication

--- a/src/__tests__/api-activity.test.ts
+++ b/src/__tests__/api-activity.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createApiKey } from "@/__tests__/test-helpers";
 import { createTestDb, _setDb, migrate } from "@/lib/db";
 import type { Client } from "@libsql/client";
 import { POST as connectPOST } from "@/app/api/connect/route";
-import { POST as keysPOST } from "@/app/api/keys/route";
 import { GET as matchesGET } from "@/app/api/matches/[profileId]/route";
 import { GET as activityGET } from "@/app/api/activity/route";
 import { POST as messagesPOST } from "@/app/api/deals/[matchId]/messages/route";
@@ -15,16 +15,7 @@ let restore: () => void;
 let aliceKey: string;
 let bobKey: string;
 
-async function getApiKey(agentId: string): Promise<string> {
-  const req = new NextRequest("http://localhost:3000/api/keys", {
-    method: "POST",
-    body: JSON.stringify({ agent_id: agentId }),
-    headers: { "Content-Type": "application/json" },
-  });
-  const res = await keysPOST(req);
-  const data = await res.json();
-  return data.api_key;
-}
+async function getApiKey(agentId: string): Promise<string> { return createApiKey(agentId); }
 
 beforeEach(async () => {
   _resetRateLimitStore();

--- a/src/__tests__/api-connect.test.ts
+++ b/src/__tests__/api-connect.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createApiKey } from "@/__tests__/test-helpers";
 import { createTestDb, _setDb, migrate } from "@/lib/db";
 import type { Client } from "@libsql/client";
 import { POST, DELETE } from "@/app/api/connect/route";
-import { POST as keysPOST } from "@/app/api/keys/route";
 import { NextRequest } from "next/server";
 
 let db: Client;
@@ -18,16 +18,7 @@ afterEach(() => {
   restore();
 });
 
-async function getApiKey(agentId: string): Promise<string> {
-  const req = new NextRequest("http://localhost:3000/api/keys", {
-    method: "POST",
-    body: JSON.stringify({ agent_id: agentId }),
-    headers: { "Content-Type": "application/json" },
-  });
-  const res = await keysPOST(req);
-  const data = await res.json();
-  return data.api_key;
-}
+async function getApiKey(agentId: string): Promise<string> { return createApiKey(agentId); }
 
 function makeRequest(method: string, body?: unknown, query?: string, apiKey?: string): NextRequest {
   const url = `http://localhost:3000/api/connect${query ? `?${query}` : ""}`;

--- a/src/__tests__/api-deals.test.ts
+++ b/src/__tests__/api-deals.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createApiKey } from "@/__tests__/test-helpers";
 import { createTestDb, _setDb, migrate } from "@/lib/db";
 import type { Client } from "@libsql/client";
 import { POST as connectPOST } from "@/app/api/connect/route";
-import { POST as keysPOST } from "@/app/api/keys/route";
 import { GET as matchesGET } from "@/app/api/matches/[profileId]/route";
 import { GET as dealsGET } from "@/app/api/deals/route";
 import { GET as dealDetailGET } from "@/app/api/deals/[matchId]/route";
@@ -17,16 +17,7 @@ let restore: () => void;
 let aliceKey: string;
 let bobKey: string;
 
-async function getApiKey(agentId: string): Promise<string> {
-  const req = new NextRequest("http://localhost:3000/api/keys", {
-    method: "POST",
-    body: JSON.stringify({ agent_id: agentId }),
-    headers: { "Content-Type": "application/json" },
-  });
-  const res = await keysPOST(req);
-  const data = await res.json();
-  return data.api_key;
-}
+async function getApiKey(agentId: string): Promise<string> { return createApiKey(agentId); }
 
 beforeEach(async () => {
   db = createTestDb();

--- a/src/__tests__/api-inbox.test.ts
+++ b/src/__tests__/api-inbox.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createTestDb, _setDb, migrate } from "@/lib/db";
 import type { Client } from "@libsql/client";
-import { POST as keysPOST } from "@/app/api/keys/route";
+import { createApiKey } from "@/__tests__/test-helpers";
 import { POST as connectPOST } from "@/app/api/connect/route";
 import { GET as matchesGET } from "@/app/api/matches/[profileId]/route";
 import { POST as messagesPOST } from "@/app/api/deals/[matchId]/messages/route";
@@ -30,15 +30,7 @@ afterEach(() => {
   restore();
 });
 
-async function getApiKey(agentId: string): Promise<string> {
-  const res = await keysPOST(req("/api/keys", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ agent_id: agentId }),
-  }));
-  const data = await res.json();
-  return data.api_key;
-}
+async function getApiKey(agentId: string): Promise<string> { return createApiKey(agentId); }
 
 async function createProfile(agentId: string, apiKey: string, side: string) {
   const res = await connectPOST(req("/api/connect", {

--- a/src/__tests__/api-market.test.ts
+++ b/src/__tests__/api-market.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createApiKey } from "@/__tests__/test-helpers";
 import { createTestDb, _setDb, migrate } from "@/lib/db";
 import type { Client } from "@libsql/client";
 import { GET } from "@/app/api/market/[category]/route";
 import { POST as connectPOST } from "@/app/api/connect/route";
-import { POST as keysPOST } from "@/app/api/keys/route";
 import { NextRequest } from "next/server";
 
 let db: Client;
@@ -19,16 +19,7 @@ afterEach(() => {
   restore();
 });
 
-async function getApiKey(agentId: string): Promise<string> {
-  const req = new NextRequest("http://localhost:3000/api/keys", {
-    method: "POST",
-    body: JSON.stringify({ agent_id: agentId }),
-    headers: { "Content-Type": "application/json" },
-  });
-  const res = await keysPOST(req);
-  const data = await res.json();
-  return data.api_key;
-}
+async function getApiKey(agentId: string): Promise<string> { return createApiKey(agentId); }
 
 async function createProfile(
   agentId: string,

--- a/src/__tests__/api-milestones.test.ts
+++ b/src/__tests__/api-milestones.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createApiKey } from "@/__tests__/test-helpers";
 import { createTestDb, _setDb, migrate } from "@/lib/db";
 import type { Client } from "@libsql/client";
 import { POST as connectPOST } from "@/app/api/connect/route";
-import { POST as keysPOST } from "@/app/api/keys/route";
 import { GET as matchesGET } from "@/app/api/matches/[profileId]/route";
 import { POST as messagesPOST } from "@/app/api/deals/[matchId]/messages/route";
 import { GET as milestonesGET, POST as milestonesPOST } from "@/app/api/deals/[matchId]/milestones/route";
@@ -22,16 +22,7 @@ afterEach(() => {
   restore();
 });
 
-async function getApiKey(agentId: string): Promise<string> {
-  const req = new NextRequest("http://localhost:3000/api/keys", {
-    method: "POST",
-    body: JSON.stringify({ agent_id: agentId }),
-    headers: { "Content-Type": "application/json" },
-  });
-  const res = await keysPOST(req);
-  const data = await res.json();
-  return data.api_key;
-}
+async function getApiKey(agentId: string): Promise<string> { return createApiKey(agentId); }
 
 async function createProfile(agentId: string, side: string, category: string, params: Record<string, unknown>, apiKey: string) {
   const req = new NextRequest("http://localhost:3000/api/connect", {

--- a/src/__tests__/api-projects.test.ts
+++ b/src/__tests__/api-projects.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createApiKey } from "@/__tests__/test-helpers";
 import { createTestDb, _setDb, migrate } from "@/lib/db";
 import type { Client } from "@libsql/client";
 import { POST as projectsPOST, GET as projectsGET } from "@/app/api/projects/route";
@@ -7,7 +8,6 @@ import { POST as joinPOST } from "@/app/api/projects/[projectId]/join/route";
 import { POST as messagesPOST } from "@/app/api/projects/[projectId]/messages/route";
 import { POST as approvePOST } from "@/app/api/projects/[projectId]/approve/route";
 import { POST as leavePOST } from "@/app/api/projects/[projectId]/leave/route";
-import { POST as keysPOST } from "@/app/api/keys/route";
 import { NextRequest } from "next/server";
 
 let db: Client;
@@ -23,16 +23,7 @@ afterEach(() => {
   restore();
 });
 
-async function getApiKey(agentId: string): Promise<string> {
-  const req = new NextRequest("http://localhost:3000/api/keys", {
-    method: "POST",
-    body: JSON.stringify({ agent_id: agentId }),
-    headers: { "Content-Type": "application/json" },
-  });
-  const res = await keysPOST(req);
-  const data = await res.json();
-  return data.api_key;
-}
+async function getApiKey(agentId: string): Promise<string> { return createApiKey(agentId); }
 
 function makeParams(projectId: string) {
   return { params: Promise.resolve({ projectId }) };

--- a/src/__tests__/api-reputation.test.ts
+++ b/src/__tests__/api-reputation.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createApiKey } from "@/__tests__/test-helpers";
 import { createTestDb, _setDb, migrate } from "@/lib/db";
 import type { Client } from "@libsql/client";
 import { POST as connectPOST } from "@/app/api/connect/route";
-import { POST as keysPOST } from "@/app/api/keys/route";
 import { GET as matchesGET } from "@/app/api/matches/[profileId]/route";
 import { POST as messagesPOST } from "@/app/api/deals/[matchId]/messages/route";
 import { POST as approvePOST } from "@/app/api/deals/[matchId]/approve/route";
@@ -16,16 +16,7 @@ let restore: () => void;
 let aliceKey: string;
 let bobKey: string;
 
-async function getApiKey(agentId: string): Promise<string> {
-  const req = new NextRequest("http://localhost:3000/api/keys", {
-    method: "POST",
-    body: JSON.stringify({ agent_id: agentId }),
-    headers: { "Content-Type": "application/json" },
-  });
-  const res = await keysPOST(req);
-  const data = await res.json();
-  return data.api_key;
-}
+async function getApiKey(agentId: string): Promise<string> { return createApiKey(agentId); }
 
 beforeEach(async () => {
   db = createTestDb();

--- a/src/__tests__/api-search.test.ts
+++ b/src/__tests__/api-search.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createApiKey } from "@/__tests__/test-helpers";
 import { createTestDb, _setDb, migrate } from "@/lib/db";
 import type { Client } from "@libsql/client";
 import { POST as connectPOST } from "@/app/api/connect/route";
-import { POST as keysPOST } from "@/app/api/keys/route";
 import { GET as searchGET } from "@/app/api/search/route";
 import { PATCH as profilePATCH } from "@/app/api/profiles/[profileId]/route";
 import { POST as reviewPOST } from "@/app/api/reputation/[agentId]/review/route";
@@ -21,16 +21,7 @@ afterEach(() => {
   restore();
 });
 
-async function getApiKey(agentId: string): Promise<string> {
-  const req = new NextRequest("http://localhost:3000/api/keys", {
-    method: "POST",
-    body: JSON.stringify({ agent_id: agentId }),
-    headers: { "Content-Type": "application/json" },
-  });
-  const res = await keysPOST(req);
-  const data = await res.json();
-  return data.api_key;
-}
+async function getApiKey(agentId: string): Promise<string> { return createApiKey(agentId); }
 
 async function registerProfile(agentId: string, apiKey: string, overrides: Record<string, unknown> = {}) {
   const body = {

--- a/src/__tests__/api-tags.test.ts
+++ b/src/__tests__/api-tags.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createApiKey } from "@/__tests__/test-helpers";
 import { createTestDb, _setDb, migrate } from "@/lib/db";
 import type { Client } from "@libsql/client";
 import { POST } from "@/app/api/connect/route";
@@ -6,7 +7,6 @@ import { GET as getProfile, PATCH as patchProfile } from "@/app/api/profiles/[pr
 import { GET as getAgentProfiles } from "@/app/api/connect/[agentId]/route";
 import { GET as searchProfiles } from "@/app/api/search/route";
 import { GET as getTags } from "@/app/api/tags/route";
-import { POST as keysPOST } from "@/app/api/keys/route";
 import { NextRequest } from "next/server";
 
 let db: Client;
@@ -22,16 +22,7 @@ afterEach(() => {
   restore();
 });
 
-async function getApiKey(agentId: string): Promise<string> {
-  const req = new NextRequest("http://localhost:3000/api/keys", {
-    method: "POST",
-    body: JSON.stringify({ agent_id: agentId }),
-    headers: { "Content-Type": "application/json" },
-  });
-  const res = await keysPOST(req);
-  const data = await res.json();
-  return data.api_key;
-}
+async function getApiKey(agentId: string): Promise<string> { return createApiKey(agentId); }
 
 function makeConnectRequest(body: unknown, apiKey?: string): NextRequest {
   const headers: Record<string, string> = { "Content-Type": "application/json" };

--- a/src/__tests__/api-templates.test.ts
+++ b/src/__tests__/api-templates.test.ts
@@ -1,23 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createApiKey } from "@/__tests__/test-helpers";
 import { createTestDb, _setDb, migrate } from "@/lib/db";
 import type { Client } from "@libsql/client";
 import { GET as templatesGET, POST as templatesPOST } from "@/app/api/templates/route";
-import { POST as keysPOST } from "@/app/api/keys/route";
 import { NextRequest } from "next/server";
 
 let db: Client;
 let restore: () => void;
 
-async function getApiKey(agentId: string): Promise<string> {
-  const req = new NextRequest("http://localhost:3000/api/keys", {
-    method: "POST",
-    body: JSON.stringify({ agent_id: agentId }),
-    headers: { "Content-Type": "application/json" },
-  });
-  const res = await keysPOST(req);
-  const data = await res.json();
-  return data.api_key;
-}
+async function getApiKey(agentId: string): Promise<string> { return createApiKey(agentId); }
 
 beforeEach(async () => {
   db = createTestDb();

--- a/src/__tests__/api-webhooks.test.ts
+++ b/src/__tests__/api-webhooks.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createTestDb, _setDb, migrate } from "@/lib/db";
 import type { Client } from "@libsql/client";
-import { POST as keysPOST } from "@/app/api/keys/route";
+import { createApiKey } from "@/__tests__/test-helpers";
 import { GET as webhooksGET, POST as webhooksPOST } from "@/app/api/webhooks/route";
 import { DELETE as webhookDELETE, PATCH as webhookPATCH } from "@/app/api/webhooks/[id]/route";
 import { NextRequest } from "next/server";
@@ -26,15 +26,7 @@ afterEach(() => {
   restore();
 });
 
-async function getApiKey(agentId: string): Promise<string> {
-  const res = await keysPOST(req("/api/keys", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ agent_id: agentId }),
-  }));
-  const data = await res.json();
-  return data.api_key;
-}
+async function getApiKey(agentId: string): Promise<string> { return createApiKey(agentId); }
 
 describe("Webhooks API", () => {
   it("registers a webhook", async () => {

--- a/src/__tests__/proxy.test.ts
+++ b/src/__tests__/proxy.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from "vitest";
 
 // Mirror the proxy logic for testing
-const PUBLIC_ANY_METHOD = ["/", "/login", "/register", "/api/register", "/api/login", "/api/keys"];
+const PUBLIC_ANY_METHOD = ["/", "/login", "/register", "/api/register", "/api/login"];
 const PUBLIC_GET_ONLY = ["/api/stats", "/api/categories", "/api/search", "/api/tags", "/api/templates", "/api/projects", "/api/openapi.json"];
 const PUBLIC_GET_PREFIXES = ["/api/agents/", "/api/reputation/", "/api/market/", "/api/connect/", "/api/profiles/"];
 
@@ -31,7 +31,10 @@ describe("proxy public paths", () => {
   test("allows POST on auth endpoints", () => {
     expect(isPublicPath("/api/register", "POST")).toBe(true);
     expect(isPublicPath("/api/login", "POST")).toBe(true);
-    expect(isPublicPath("/api/keys", "POST")).toBe(true);
+  });
+
+  test("blocks unauthenticated POST on /api/keys", () => {
+    expect(isPublicPath("/api/keys", "POST")).toBe(false);
   });
 
   test("allows GET on prefix-matched public paths", () => {

--- a/src/__tests__/test-helpers.ts
+++ b/src/__tests__/test-helpers.ts
@@ -1,0 +1,17 @@
+import { generateApiKey } from "@/lib/auth";
+import { ensureDb } from "@/lib/db";
+
+/**
+ * Create an API key for an agent directly in the database.
+ * Use this instead of calling the /api/keys endpoint (which requires auth).
+ */
+export async function createApiKey(agentId: string): Promise<string> {
+  const { raw, hash } = generateApiKey();
+  const id = crypto.randomUUID();
+  const db = await ensureDb();
+  await db.execute({
+    sql: "INSERT INTO api_keys (id, agent_id, key_hash) VALUES (?, ?, ?)",
+    args: [id, agentId, hash],
+  });
+  return raw;
+}

--- a/src/app/api/keys/route.ts
+++ b/src/app/api/keys/route.ts
@@ -1,41 +1,29 @@
 import { NextRequest, NextResponse } from "next/server";
 import { ensureDb } from "@/lib/db";
-import { generateApiKey } from "@/lib/auth";
+import { generateApiKey, authenticateRequest } from "@/lib/auth";
 import { checkRateLimit, RATE_LIMITS } from "@/lib/rate-limit";
 
 export async function POST(req: NextRequest) {
   const rateLimited = checkRateLimit(req, RATE_LIMITS.KEY_GEN.limit, RATE_LIMITS.KEY_GEN.windowMs, RATE_LIMITS.KEY_GEN.prefix);
   if (rateLimited) return rateLimited;
-  let body: unknown;
-  try {
-    body = await req.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+
+  const auth = await authenticateRequest(req);
+  if (!auth) {
+    return NextResponse.json({ error: "Authentication required. Use Bearer token." }, { status: 401 });
   }
 
-  if (!body || typeof body !== "object") {
-    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
-  }
-
-  const b = body as Record<string, unknown>;
-
-  if (!b.agent_id || typeof b.agent_id !== "string" || b.agent_id.trim().length === 0) {
-    return NextResponse.json({ error: "agent_id is required and must be a non-empty string" }, { status: 400 });
-  }
-
-  const agentId = b.agent_id.trim();
   const { raw, hash } = generateApiKey();
   const id = crypto.randomUUID();
 
   const db = await ensureDb();
   await db.execute({
     sql: "INSERT INTO api_keys (id, agent_id, key_hash) VALUES (?, ?, ?)",
-    args: [id, agentId, hash],
+    args: [id, auth.agent_id, hash],
   });
 
   return NextResponse.json({
     api_key: raw,
-    agent_id: agentId,
+    agent_id: auth.agent_id,
     key_id: id,
   }, { status: 201 });
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3,7 +3,7 @@ import { hashSessionToken, SESSION_COOKIE_NAME } from "@/lib/auth";
 import { ensureDb } from "@/lib/db";
 
 // Paths accessible without auth for any method (auth endpoints that need POST)
-const PUBLIC_ANY_METHOD = ["/", "/login", "/register", "/api/register", "/api/login", "/api/keys"];
+const PUBLIC_ANY_METHOD = ["/", "/login", "/register", "/api/register", "/api/login"];
 // Paths accessible without auth for GET only (read-only discovery)
 const PUBLIC_GET_ONLY = ["/api/stats", "/api/categories", "/api/search", "/api/tags", "/api/templates", "/api/projects", "/api/openapi.json"];
 const PUBLIC_GET_PREFIXES = ["/api/agents/", "/api/reputation/", "/api/market/", "/api/connect/", "/api/profiles/"];


### PR DESCRIPTION
## Security Fix

`/api/keys` was publicly accessible - anyone who knew an agent_id could generate new API keys for that agent, effectively taking over their account.

### Changes
- `/api/keys` now requires Bearer token authentication
- Keys are generated for the authenticated agent (no agent_id body param needed)
- Removed `/api/keys` from public proxy allowlist
- Updated negotiate skill docs to reflect auth requirement
- Added shared test helper (`createApiKey`) to reduce code duplication across test files

### Testing
- 275 tests passing (+1 new auth test)
- Typecheck clean
- Battle-tested full negotiate skill flow against production API