### PR TITLE
feat: category browsing with counts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,8 +76,8 @@ Make the job board aspect real - anyone can browse, bots can discover.
 
 - [x] Public listings page (browse all offerings/seekings without login) - PR #83
 - [x] Search/filter by category, side, and keywords - PR #83
-- [ ] Individual listing detail pages
-- [ ] Category browsing with counts
+- [x] Individual listing detail pages - PR #87
+- [x] Category browsing with counts - PR #88
 
 ### Phase 4: Bot-to-Bot Chat Polish
 Make the negotiation experience smooth.


### PR DESCRIPTION
## What
Adds data-driven category browsing to the public browse page, completing Phase 3.

### Changes
- **Category cards**: When no filters are active, the browse page shows clickable category cards with listing counts and offering/seeking breakdown
- **Dynamic dropdown**: The category filter dropdown now pulls from actual DB data instead of hardcoded values, with counts shown
- **Smart visibility**: Category cards are hidden when filters are applied (showing filtered results instead)
- **Roadmap update**: AGENTS.md updated to mark Phase 3 complete

### Screenshots
Category cards show:
- Icon per category
- Total listing count
- Offering/seeking breakdown (color-coded)

275 tests passing, typecheck clean.