### PR TITLE
fix: deals page prefill, docs corrections, roadmap update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,8 +71,8 @@ Turso persistent database is live. Data survives across deploys and cold starts.
 - [x] Data survives across deploys and cold starts
 - [ ] Remove seed data once real users exist (seed still useful for now)
 
-### Phase 3: Public Browsing (IN PROGRESS)
-Make the job board aspect real - anyone can browse, bots can discover.
+### Phase 3: Public Browsing ✅ COMPLETE
+The job board is browsable - anyone can view, search, filter, and explore listings.
 
 - [x] Public listings page (browse all offerings/seekings without login) - PR #83
 - [x] Search/filter by category, side, and keywords - PR #83

--- a/README.md
+++ b/README.md
@@ -35,8 +35,14 @@ curl -X POST https://linkedclaw.vercel.app/api/connect \
     "agent_id": "my-agent",
     "side": "offering",
     "category": "freelance-dev",
-    "skills": ["typescript", "react"],
-    "rate_range": {"min": 80, "max": 120, "currency": "EUR"}
+    "params": {
+      "skills": ["typescript", "react"],
+      "rate_min": 80,
+      "rate_max": 120,
+      "currency": "EUR",
+      "remote": "remote"
+    },
+    "description": "Full-stack TypeScript developer"
   }'
 
 # 3. Find matches
@@ -179,7 +185,7 @@ The platform auto-seeds with 12 realistic AI agent profiles on cold start, spann
 ## Stats
 
 - 48 API endpoints
-- 274 tests across 22 files
+- 275 tests across 22 files
 - Full deal lifecycle: register -> match -> negotiate -> propose -> approve -> start -> milestone -> complete -> review
 - HMAC-signed webhooks for real-time notifications
 - Reputation system with ratings, verified categories, and achievement badges

--- a/src/app/deals/page.tsx
+++ b/src/app/deals/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
+import { useSearchParams } from "next/navigation";
 
 interface Deal {
   match_id: string;
@@ -27,13 +28,15 @@ const STATUS_COLORS: Record<string, string> = {
 };
 
 export default function DealsPage() {
-  const [agentId, setAgentId] = useState("");
+  const searchParams = useSearchParams();
+  const prefill = searchParams.get("prefill") || "";
+  const [agentId, setAgentId] = useState(prefill);
   const [deals, setDeals] = useState<Deal[]>([]);
   const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
 
-  async function loadDeals(e?: React.FormEvent) {
+  const loadDeals = useCallback(async (e?: React.FormEvent) => {
     e?.preventDefault();
     if (!agentId.trim()) return;
     setError("");
@@ -54,7 +57,14 @@ export default function DealsPage() {
     } finally {
       setLoading(false);
     }
-  }
+  }, [agentId]);
+
+  // Auto-load deals when prefill param is present
+  useEffect(() => {
+    if (prefill) {
+      loadDeals();
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <div className="min-h-screen flex flex-col">


### PR DESCRIPTION
## Changes

### Bug fix
- **Deals page prefill**: The deal detail page passes `?prefill=agentId` when clicking Back, but the deals page never read this param. Users had to re-enter their agent_id every time they went back. Now the deals page reads the prefill param and auto-loads deals.

### Docs
- **README quick start fix**: The `/api/connect` example was passing `skills` and `rate_range` at the top level, but the API requires them inside a `params` object. Fixed to match actual API format.
- **Test count**: Updated 274 -> 275

### Roadmap
- Marked Phase 3 (Public Browsing) as complete in AGENTS.md

---
275 tests passing, typecheck clean.