### PR TITLE
fix: nav consistency and login redirect bug

### DIFF
--- a/src/app/connect/page.tsx
+++ b/src/app/connect/page.tsx
@@ -53,9 +53,12 @@ export default function ConnectPage() {
 
   return (
     <div className="min-h-screen flex flex-col">
-      <nav className="border-b border-gray-200 dark:border-gray-800 px-6 py-4 flex gap-6">
+      <nav className="border-b border-gray-200 dark:border-gray-800 px-6 py-4 flex items-center gap-6">
         <Link href="/" className="font-bold text-lg">
-          LinkedClaw
+          🦞 LinkedClaw
+        </Link>
+        <Link href="/browse" className="text-gray-600 dark:text-gray-400 hover:text-foreground">
+          Browse
         </Link>
         <Link href="/deals" className="text-gray-600 dark:text-gray-400 hover:text-foreground">
           Deals

--- a/src/app/deals/[matchId]/page.tsx
+++ b/src/app/deals/[matchId]/page.tsx
@@ -318,9 +318,12 @@ export default function DealDetailPage() {
 
 function Nav() {
   return (
-    <nav className="border-b border-gray-200 dark:border-gray-800 px-6 py-4 flex gap-6">
+    <nav className="border-b border-gray-200 dark:border-gray-800 px-6 py-4 flex items-center gap-6">
       <Link href="/" className="font-bold text-lg">
-        LinkedClaw
+        🦞 LinkedClaw
+      </Link>
+      <Link href="/browse" className="text-gray-600 dark:text-gray-400 hover:text-foreground">
+        Browse
       </Link>
       <Link href="/connect" className="text-gray-600 dark:text-gray-400 hover:text-foreground">
         Connect

--- a/src/app/deals/page.tsx
+++ b/src/app/deals/page.tsx
@@ -68,9 +68,12 @@ export default function DealsPage() {
 
   return (
     <div className="min-h-screen flex flex-col">
-      <nav className="border-b border-gray-200 dark:border-gray-800 px-6 py-4 flex gap-6">
+      <nav className="border-b border-gray-200 dark:border-gray-800 px-6 py-4 flex items-center gap-6">
         <Link href="/" className="font-bold text-lg">
-          LinkedClaw
+          🦞 LinkedClaw
+        </Link>
+        <Link href="/browse" className="text-gray-600 dark:text-gray-400 hover:text-foreground">
+          Browse
         </Link>
         <Link href="/connect" className="text-gray-600 dark:text-gray-400 hover:text-foreground">
           Connect

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -21,7 +21,7 @@ export default function LoginPage() {
         body: JSON.stringify({ username, password }),
       });
       const data = await res.json();
-      if (res.ok) { router.push("/dashboard"); }
+      if (res.ok) { router.push("/deals"); }
       else { setError(data.error || "Login failed"); }
     } catch { setError("Network error"); }
     finally { setLoading(false); }


### PR DESCRIPTION
## Changes

- **Nav consistency:** Added 🦞 emoji to nav bar on connect, deals, and deal detail pages (was missing, only showed plain 'LinkedClaw')
- **Nav links:** Added Browse link to authenticated page navs for easier navigation
- **Login redirect fix:** Login was redirecting to `/dashboard` which doesn't exist (404). Now redirects to `/deals` which is the correct authenticated landing page.

## Testing
- 275 tests passing
- Typecheck clean