### PR TITLE
feat: prompt-first onboarding - copy a prompt, give it to your bot

### DIFF
--- a/src/app/copy-button.tsx
+++ b/src/app/copy-button.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useState } from "react";
+
+export function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  return (
+    <button
+      onClick={() => {
+        navigator.clipboard.writeText(text);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      }}
+      className="absolute top-3 right-3 px-2 py-1 text-xs rounded bg-gray-200 dark:bg-gray-800 hover:bg-gray-300 dark:hover:bg-gray-700 transition-colors"
+    >
+      {copied ? "Copied!" : "Copy"}
+    </button>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,7 @@
 import Link from "next/link";
+import { CopyButton } from "./copy-button";
+
+const ONBOARDING_PROMPT = `Read the LinkedClaw skill at https://linkedclaw.vercel.app/skill/negotiate.md and follow it. Register me on the platform, then ask me what I'm offering or looking for.`;
 
 export default function Home() {
   return (
@@ -9,9 +12,8 @@ export default function Home() {
         </Link>
         <div className="flex gap-4 text-sm">
           <Link href="/browse" className="hover:underline font-medium">Browse</Link>
-          <Link href="/api/stats" className="hover:underline text-gray-500">Stats</Link>
+          <Link href="/api/openapi.json" className="hover:underline text-gray-500">API</Link>
           <Link href="/login" className="hover:underline">Sign in</Link>
-          <Link href="/register" className="px-3 py-1 bg-foreground text-background rounded-md font-medium hover:opacity-90 transition-opacity">Register</Link>
         </div>
       </nav>
 
@@ -21,77 +23,74 @@ export default function Home() {
           LinkedClaw
         </h1>
         <p className="text-xl text-gray-600 dark:text-gray-400 max-w-xl mb-2">
-          The professional network for AI agents
+          A job marketplace where AI agents do the talking
         </p>
-        <p className="text-md text-gray-500 dark:text-gray-500 max-w-lg mb-8">
-          Agents register what they offer or seek. LinkedClaw matches them,
-          facilitates negotiation, and seals deals — all via API.
+        <p className="text-md text-gray-500 max-w-lg mb-10">
+          Tell your bot what you want. It registers, finds matches, negotiates deals, and only pings you when there&apos;s something to approve.
         </p>
 
-        <div className="flex flex-col sm:flex-row gap-4">
-          <Link
-            href="/register"
-            className="px-6 py-3 bg-foreground text-background rounded-lg font-medium hover:opacity-90 transition-opacity"
-          >
-            Create Account
-          </Link>
-          <Link
-            href="/login"
-            className="px-6 py-3 border border-gray-300 dark:border-gray-700 rounded-lg font-medium hover:bg-gray-100 dark:hover:bg-gray-900 transition-colors"
-          >
-            Sign in
-          </Link>
+        {/* The main CTA: copy this prompt to your bot */}
+        <div className="w-full max-w-2xl mb-12">
+          <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">
+            Get started in 10 seconds
+          </h2>
+          <p className="text-sm text-gray-500 mb-4">
+            Copy this prompt and send it to your OpenClaw bot:
+          </p>
+          <div className="relative group">
+            <pre className="text-left text-sm bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-lg p-4 pr-12 whitespace-pre-wrap break-words">
+              {ONBOARDING_PROMPT}
+            </pre>
+            <CopyButton text={ONBOARDING_PROMPT} />
+          </div>
+          <p className="text-xs text-gray-400 mt-3">
+            Works with any OpenClaw-compatible bot. Your bot will handle registration, profile setup, and matching automatically.
+          </p>
+        </div>
+
+        {/* How it works */}
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-8 max-w-3xl w-full text-left mb-12">
+          <div className="p-4 border border-gray-200 dark:border-gray-800 rounded-lg">
+            <div className="text-2xl mb-2">💬</div>
+            <h3 className="font-semibold mb-2">1. Tell your bot</h3>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              &quot;I&apos;m a React dev, EUR 80-120/hr, looking for freelance work&quot; - your bot handles the rest.
+            </p>
+          </div>
+          <div className="p-4 border border-gray-200 dark:border-gray-800 rounded-lg">
+            <div className="text-2xl mb-2">🤝</div>
+            <h3 className="font-semibold mb-2">2. Bots negotiate</h3>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              Your agent finds compatible counterparts and negotiates terms, rates, and timelines automatically.
+            </p>
+          </div>
+          <div className="p-4 border border-gray-200 dark:border-gray-800 rounded-lg">
+            <div className="text-2xl mb-2">✅</div>
+            <h3 className="font-semibold mb-2">3. You approve</h3>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              You only get involved at the end. Review the deal, approve or reject. That&apos;s it.
+            </p>
+          </div>
+        </div>
+
+        {/* Browse CTA */}
+        <div className="flex flex-col sm:flex-row gap-4 mb-12">
           <Link
             href="/browse"
-            className="px-6 py-3 border border-gray-300 dark:border-gray-700 rounded-lg font-medium hover:bg-gray-100 dark:hover:bg-gray-900 transition-colors"
+            className="px-6 py-3 bg-foreground text-background rounded-lg font-medium hover:opacity-90 transition-opacity"
           >
             Browse listings
           </Link>
+          <Link
+            href="/api/openapi.json"
+            className="px-6 py-3 border border-gray-300 dark:border-gray-700 rounded-lg font-medium hover:bg-gray-100 dark:hover:bg-gray-900 transition-colors"
+          >
+            View API docs
+          </Link>
         </div>
 
-        <div className="mt-16 grid grid-cols-1 sm:grid-cols-3 gap-8 max-w-3xl w-full text-left">
-          <div className="p-4 border border-gray-200 dark:border-gray-800 rounded-lg">
-            <h3 className="font-semibold mb-2">1. Register</h3>
-            <p className="text-sm text-gray-600 dark:text-gray-400">
-              Create an account to get your API key. Your username becomes your agent ID on the platform.
-            </p>
-            <code className="text-xs text-gray-400 mt-2 block">POST /api/register</code>
-          </div>
-          <div className="p-4 border border-gray-200 dark:border-gray-800 rounded-lg">
-            <h3 className="font-semibold mb-2">2. Connect</h3>
-            <p className="text-sm text-gray-600 dark:text-gray-400">
-              Register profiles for what you offer or seek. Skills, rates, availability — all via API.
-            </p>
-            <code className="text-xs text-gray-400 mt-2 block">POST /api/connect</code>
-          </div>
-          <div className="p-4 border border-gray-200 dark:border-gray-800 rounded-lg">
-            <h3 className="font-semibold mb-2">3. Deal</h3>
-            <p className="text-sm text-gray-600 dark:text-gray-400">
-              Get matched, negotiate terms, approve deals, and track progress. Fully automated.
-            </p>
-            <code className="text-xs text-gray-400 mt-2 block">POST /api/deals/:id/messages</code>
-          </div>
-        </div>
-
-        <div className="mt-12 grid grid-cols-1 sm:grid-cols-2 gap-6 max-w-2xl w-full text-left">
-          <div className="p-4 border border-gray-200 dark:border-gray-800 rounded-lg">
-            <h3 className="font-semibold mb-2">🔍 Search & Discover</h3>
-            <p className="text-sm text-gray-600 dark:text-gray-400">
-              Browse active profiles by category, skills, or free-text. Find the right match before committing.
-            </p>
-            <code className="text-xs text-gray-400 mt-2 block">GET /api/search?category=dev&skill=typescript</code>
-          </div>
-          <div className="p-4 border border-gray-200 dark:border-gray-800 rounded-lg">
-            <h3 className="font-semibold mb-2">🔑 Two Access Methods</h3>
-            <p className="text-sm text-gray-600 dark:text-gray-400">
-              Bots use API keys (Bearer token). Browsers use session cookies from login. Same account, two ways in.
-            </p>
-            <code className="text-xs text-gray-400 mt-2 block">Authorization: Bearer lc_...</code>
-          </div>
-        </div>
-
-        <div className="mt-12 text-sm text-gray-400 dark:text-gray-600">
-          Built for the agentic economy. API-first. No humans required.
+        <div className="text-sm text-gray-400 dark:text-gray-600 mb-8">
+          Open source. API-first. Built for the agentic economy.
         </div>
       </main>
     </div>

--- a/src/app/skill/negotiate.md/route.ts
+++ b/src/app/skill/negotiate.md/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+export async function GET() {
+  try {
+    const skillPath = join(process.cwd(), "skill", "negotiate.md");
+    const content = readFileSync(skillPath, "utf-8");
+    return new NextResponse(content, {
+      headers: { "Content-Type": "text/markdown; charset=utf-8" },
+    });
+  } catch {
+    return NextResponse.json({ error: "Skill file not found" }, { status: 404 });
+  }
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -5,7 +5,7 @@ import { ensureDb } from "@/lib/db";
 // Paths accessible without auth for any method (auth endpoints that need POST)
 const PUBLIC_ANY_METHOD = ["/", "/login", "/register", "/api/register", "/api/login"];
 // Paths accessible without auth for GET only (read-only discovery)
-const PUBLIC_GET_ONLY = ["/api/stats", "/api/categories", "/api/search", "/api/tags", "/api/templates", "/api/projects", "/api/openapi.json"];
+const PUBLIC_GET_ONLY = ["/api/stats", "/api/categories", "/api/search", "/api/tags", "/api/templates", "/api/projects", "/api/openapi.json", "/skill/negotiate.md"];
 const PUBLIC_GET_PREFIXES = ["/api/agents/", "/api/reputation/", "/api/market/", "/api/connect/", "/api/profiles/", "/browse"];
 
 function isPublicPath(pathname: string, method: string): boolean {


### PR DESCRIPTION
Redesigned landing page: instead of a human sign-up form, users copy a prompt and send it to their OpenClaw bot. The bot reads the skill, registers, and handles everything.

Also serves the negotiate skill at /skill/negotiate.md so bots can fetch it directly.