### PR TITLE
fix: show send errors + add Inbox nav link to all pages

### DIFF
--- a/src/app/connect/page.tsx
+++ b/src/app/connect/page.tsx
@@ -65,6 +65,9 @@ export default function ConnectPage() {
         <Link href="/deals" className="text-gray-600 dark:text-gray-400 hover:text-foreground">
           Deals
         </Link>
+        <Link href="/inbox" className="text-gray-600 dark:text-gray-400 hover:text-foreground">
+          Inbox
+        </Link>
       </nav>
 
       <main className="flex-1 max-w-2xl mx-auto w-full px-6 py-10">

--- a/src/app/deals/[matchId]/page.tsx
+++ b/src/app/deals/[matchId]/page.tsx
@@ -69,6 +69,7 @@ export default function DealDetailPage() {
   const [approvalResult, setApprovalResult] = useState("");
   const [newMessage, setNewMessage] = useState("");
   const [sending, setSending] = useState(false);
+  const [sendError, setSendError] = useState("");
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   // Auto-detect logged-in user from localStorage if not in URL
@@ -143,6 +144,7 @@ export default function DealDetailPage() {
     e.preventDefault();
     if (!agentId || !newMessage.trim()) return;
     setSending(true);
+    setSendError("");
     try {
       const res = await fetch(`/api/deals/${matchId}/messages`, {
         method: "POST",
@@ -156,9 +158,12 @@ export default function DealDetailPage() {
       if (res.ok) {
         setNewMessage("");
         fetchDeal();
+      } else {
+        const json = await res.json().catch(() => ({}));
+        setSendError(json.error || "Failed to send message");
       }
     } catch {
-      // silently fail
+      setSendError("Failed to send message");
     } finally {
       setSending(false);
     }
@@ -303,6 +308,7 @@ export default function DealDetailPage() {
               </button>
             </form>
           )}
+          {sendError && <p className="text-xs text-red-500 dark:text-red-400 mt-1">{sendError}</p>}
           {isActive && (
             <p className="text-xs text-gray-400 mt-1">Auto-refreshing every 3 seconds</p>
           )}
@@ -429,6 +435,9 @@ function Nav() {
       </Link>
       <Link href="/deals" className="text-gray-600 dark:text-gray-400 hover:text-foreground">
         Deals
+      </Link>
+      <Link href="/inbox" className="text-gray-600 dark:text-gray-400 hover:text-foreground">
+        Inbox
       </Link>
       <div className="ml-auto flex items-center gap-4">
         {username ? (

--- a/src/app/deals/page.tsx
+++ b/src/app/deals/page.tsx
@@ -93,6 +93,9 @@ export default function DealsPage() {
         <Link href="/deals" className="text-gray-600 dark:text-gray-400 hover:text-foreground">
           Deals
         </Link>
+        <Link href="/inbox" className="text-gray-600 dark:text-gray-400 hover:text-foreground">
+          Inbox
+        </Link>
         <div className="ml-auto flex items-center gap-4">
           {agentId ? (
             <>

--- a/src/app/inbox/page.tsx
+++ b/src/app/inbox/page.tsx
@@ -166,6 +166,9 @@ function Nav({ unreadCount }: { unreadCount: number }) {
       <Link href="/browse" className="text-gray-600 dark:text-gray-400 hover:text-foreground">
         Browse
       </Link>
+      <Link href="/connect" className="text-gray-600 dark:text-gray-400 hover:text-foreground">
+        Connect
+      </Link>
       <Link href="/deals" className="text-gray-600 dark:text-gray-400 hover:text-foreground">
         Deals
       </Link>


### PR DESCRIPTION
- Deal page chat input now shows error messages instead of silently failing on send
- Added Inbox nav link to deal detail, deals list, connect, and inbox pages
- Added missing Connect nav link to inbox page
- Consistent navigation across all authenticated pages

508 tests passing, typecheck clean.