### PR TITLE
fix: cross-category matching (#122)

### DIFF
--- a/src/__tests__/matching.test.ts
+++ b/src/__tests__/matching.test.ts
@@ -63,7 +63,7 @@ describe("findMatches", () => {
     expect(matches).toHaveLength(0);
   });
 
-  it("does not match profiles in different categories", async () => {
+  it("matches across different categories when skills overlap", async () => {
     const id1 = await insertProfile("alice", "offering", "frontend-dev", {
       skills: ["react"],
     });
@@ -72,7 +72,8 @@ describe("findMatches", () => {
     });
 
     const matches = await findMatches(id1);
-    expect(matches).toHaveLength(0);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].overlap.score).toBeGreaterThan(0);
   });
 
   it("returns no match when skills don't overlap", async () => {
@@ -264,7 +265,7 @@ describe("findMatches", () => {
       rate_min: 40,
       rate_max: 60,
     });
-    // No match - different category
+    // Cross-category match - still matches on skill overlap
     await insertProfile("dave", "seeking", "design", {
       skills: ["react"],
       rate_min: 50,
@@ -272,8 +273,8 @@ describe("findMatches", () => {
     });
 
     const matches = await findMatches(id1);
-    expect(matches).toHaveLength(2);
+    expect(matches).toHaveLength(3);
     const agents = matches.map((m) => m.counterpart.agent_id).sort();
-    expect(agents).toEqual(["bob", "charlie"]);
+    expect(agents).toEqual(["bob", "charlie", "dave"]);
   });
 });

--- a/src/lib/matching.ts
+++ b/src/lib/matching.ts
@@ -14,9 +14,10 @@ export async function findMatches(
   if (!profile) return [];
 
   const oppositeSide = profile.side === "offering" ? "seeking" : "offering";
+  // Match across all categories - skills and rates are the real signals
   const candidatesResult = await db.execute({
-    sql: "SELECT * FROM profiles WHERE side = ? AND category = ? AND active = 1 AND id != ?",
-    args: [oppositeSide, profile.category, profileId],
+    sql: "SELECT * FROM profiles WHERE side = ? AND active = 1 AND agent_id != ?",
+    args: [oppositeSide, profile.agent_id],
   });
   const candidates = candidatesResult.rows as unknown as Profile[];
 
@@ -98,7 +99,7 @@ function computeOverlap(a: Profile, b: Profile): OverlapSummary | null {
     }
   }
 
-  const categoryBase = 0.3;
+  const categoryBonus = a.category === b.category ? 0.15 : 0;
 
   const minSkillSet = Math.min(aSkills.length, bSkills.length);
   let skillScore = 0.5;
@@ -122,7 +123,7 @@ function computeOverlap(a: Profile, b: Profile): OverlapSummary | null {
   const score = Math.min(
     100,
     Math.round(
-      (categoryBase + skillScore * 0.35 + rateScore * 0.2 + remoteBonus + descBonus) * 100,
+      (categoryBonus + skillScore * 0.45 + rateScore * 0.25 + remoteBonus + descBonus) * 100,
     ),
   );
 


### PR DESCRIPTION
Matching now works across categories. Skills/rates are primary signals, category is a bonus.