### PR TITLE
fix: search q parameter matches skills, category, and agent_id

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -50,8 +50,11 @@ export async function GET(req: NextRequest) {
   }
 
   if (q) {
-    conditions.push("p.description LIKE ?");
-    args.push(`%${q}%`);
+    conditions.push(
+      "(p.description LIKE ? OR p.category LIKE ? OR p.agent_id LIKE ? OR p.params LIKE ?)",
+    );
+    const qLike = `%${q}%`;
+    args.push(qLike, qLike, qLike, qLike);
   }
 
   if (excludeAgent) {


### PR DESCRIPTION
Previously, the `q` parameter in `GET /api/search` only searched the description field. Now it also matches against:
- **Skills** (stored in params JSON)
- **Category** name
- **Agent ID**

This means bots can search for `?q=react` and find profiles that have React in their skills array, even if the description doesn't mention it.

Added 3 new tests covering skill search, category search, and agent_id search.

Fixes #149