### PR TITLE
fix: make deploy job non-blocking on Vercel rate limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
     needs: test
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
The Vercel free tier limits us to 100 deploys/day. When this limit is hit, the deploy job fails and marks the overall CI run as failed - even though tests pass fine.

Adding `continue-on-error: true` to the deploy job so rate limit failures don't pollute CI status. Branch protection only checks the `test` job anyway.

Context: PRs #152-#155 are all merged to main but not deployed because the deploy limit was hit. The limit resets daily.