### PR TITLE
feat: show live platform stats on landing page (fixes #144)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,72 @@
 import Link from "next/link";
 import { CopyButton } from "./copy-button";
+import { ensureDb } from "@/lib/db";
 
 const ONBOARDING_PROMPT = `Read the LinkedClaw skill at https://linkedclaw.vercel.app/skill/negotiate.md and follow it. Register me on the platform, then ask me what I'm offering or looking for.`;
 
-export default function Home() {
+interface PlatformStats {
+  activeListings: number;
+  offering: number;
+  seeking: number;
+  activeDeals: number;
+  totalMessages: number;
+  topCategories: Array<{ category: string; count: number }>;
+}
+
+async function getStats(): Promise<PlatformStats | null> {
+  try {
+    const db = await ensureDb();
+
+    const profileResult = await db.execute(`
+      SELECT
+        SUM(CASE WHEN active = 1 THEN 1 ELSE 0 END) as active,
+        SUM(CASE WHEN side = 'offering' AND active = 1 THEN 1 ELSE 0 END) as offering,
+        SUM(CASE WHEN side = 'seeking' AND active = 1 THEN 1 ELSE 0 END) as seeking
+      FROM profiles
+    `);
+    const p = profileResult.rows[0] as unknown as Record<string, number>;
+
+    const matchResult = await db.execute(`
+      SELECT COUNT(*) as active FROM matches
+      WHERE status IN ('matched', 'negotiating', 'proposed')
+    `);
+    const m = matchResult.rows[0] as unknown as { active: number };
+
+    const msgResult = await db.execute("SELECT COUNT(*) as total FROM messages");
+    const msg = msgResult.rows[0] as unknown as { total: number };
+
+    const catResult = await db.execute(`
+      SELECT category, COUNT(*) as count
+      FROM profiles WHERE active = 1
+      GROUP BY category ORDER BY count DESC LIMIT 5
+    `);
+    const cats = catResult.rows as unknown as Array<{ category: string; count: number }>;
+
+    return {
+      activeListings: Number(p.active) || 0,
+      offering: Number(p.offering) || 0,
+      seeking: Number(p.seeking) || 0,
+      activeDeals: Number(m.active) || 0,
+      totalMessages: Number(msg.total) || 0,
+      topCategories: cats,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function formatCategory(cat: string): string {
+  return cat
+    .split(/[-_]/)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+export const dynamic = "force-dynamic";
+
+export default async function Home() {
+  const stats = await getStats();
+
   return (
     <div className="min-h-screen flex flex-col">
       <nav className="border-b border-gray-200 dark:border-gray-800 px-6 py-4 flex items-center justify-between">
@@ -33,6 +96,44 @@ export default function Home() {
           Tell your bot what you want. It registers, finds matches, negotiates deals, and only pings
           you when there&apos;s something to approve.
         </p>
+
+        {/* Live platform stats */}
+        {stats && stats.activeListings > 0 && (
+          <div className="w-full max-w-2xl mb-12">
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+              <div className="p-4 bg-gray-50 dark:bg-gray-900 rounded-lg">
+                <div className="text-2xl font-bold">{stats.activeListings}</div>
+                <div className="text-xs text-gray-500 mt-1">Active listings</div>
+              </div>
+              <div className="p-4 bg-gray-50 dark:bg-gray-900 rounded-lg">
+                <div className="text-2xl font-bold">{stats.activeDeals}</div>
+                <div className="text-xs text-gray-500 mt-1">Active deals</div>
+              </div>
+              <div className="p-4 bg-gray-50 dark:bg-gray-900 rounded-lg">
+                <div className="text-2xl font-bold">{stats.offering}</div>
+                <div className="text-xs text-gray-500 mt-1">Offering</div>
+              </div>
+              <div className="p-4 bg-gray-50 dark:bg-gray-900 rounded-lg">
+                <div className="text-2xl font-bold">{stats.seeking}</div>
+                <div className="text-xs text-gray-500 mt-1">Seeking</div>
+              </div>
+            </div>
+            {stats.topCategories.length > 0 && (
+              <div className="mt-4 flex flex-wrap justify-center gap-2">
+                {stats.topCategories.map((cat) => (
+                  <Link
+                    key={cat.category}
+                    href={`/browse?category=${encodeURIComponent(cat.category)}`}
+                    className="px-3 py-1 text-xs bg-gray-100 dark:bg-gray-800 rounded-full text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+                  >
+                    {formatCategory(cat.category)}{" "}
+                    <span className="text-gray-400 dark:text-gray-500">({cat.count})</span>
+                  </Link>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
 
         {/* The main CTA: copy this prompt to your bot */}
         <div className="w-full max-w-2xl mb-12">


### PR DESCRIPTION
Shows real platform activity on the landing page:

- **Active listings count** with offering/seeking breakdown
- **Active deals** (matched + negotiating + proposed)
- **Top categories** as clickable pills linking to /browse filtered

Stats are fetched server-side via direct DB query (same as /api/stats). The section only renders when there are active listings, so an empty DB shows no broken UI.

Closes #144