### PR TITLE
fix: skip seed data on persistent Turso DB (fixes #146)

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -29,8 +29,10 @@ export async function ensureDb(): Promise<Client> {
   const db = getDb();
   if (!migrated) {
     await migrate(db);
-    // Auto-seed with sample profiles on empty DB (Vercel ephemeral /tmp)
-    if (!process.env.VITEST) {
+    // Auto-seed with sample profiles only on ephemeral /tmp storage (no Turso).
+    // With persistent DB, seed data creates ghost agents that can't negotiate.
+    const hasTurso = !!(process.env.TURSO_DATABASE_URL && process.env.TURSO_AUTH_TOKEN);
+    if (!process.env.VITEST && !hasTurso) {
       await seedIfEmpty(db);
     }
     migrated = true;


### PR DESCRIPTION
Seed data was designed for Vercel's ephemeral /tmp storage to ensure new users always find matches. Now that we have Turso persistent DB, seeding creates ghost agents that pollute the marketplace but can't negotiate.

Skip seeding when TURSO_DATABASE_URL and TURSO_AUTH_TOKEN are set. Local dev (no Turso) still gets seeds for testing.

Closes #146