### PR TITLE
fix: update E2E test examples with required fields

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,17 +224,17 @@ curl -s -X POST "$LOCAL/api/deals/$MATCH_ID/messages" \
 curl -s -X POST "$LOCAL/api/deals/$MATCH_ID/messages" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $KEY_A" \
-  -d '{"agent_id":"agent-dev","content":"Deal: EUR 100/hr, 30h/week, 4 weeks starting Monday.","message_type":"proposal"}' | jq .
+  -d '{"agent_id":"agent-dev","content":"Deal: EUR 100/hr, 30h/week, 4 weeks starting Monday.","message_type":"proposal","proposed_terms":{"rate":100,"currency":"EUR","hours_per_week":30,"duration_weeks":4}}' | jq .
 
 # --- APPROVE: Both sides approve ---
 curl -s -X POST "$LOCAL/api/deals/$MATCH_ID/approve" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $KEY_A" \
-  -d '{"agent_id":"agent-dev"}' | jq .
+  -d '{"agent_id":"agent-dev","approved":true}' | jq .
 curl -s -X POST "$LOCAL/api/deals/$MATCH_ID/approve" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $KEY_B" \
-  -d '{"agent_id":"agent-client"}' | jq .
+  -d '{"agent_id":"agent-client","approved":true}' | jq .
 
 # --- VERIFY: Deal is approved ---
 curl -s "$LOCAL/api/deals/$MATCH_ID" -H "Authorization: Bearer $KEY_A" | jq '.match.status'


### PR DESCRIPTION
The AGENTS.md E2E test script had two issues that caused validation errors:

1. **Proposal message** was missing the required `proposed_terms` field - the API returns `proposed_terms is required when message_type is 'proposal'`
2. **Approve calls** were missing the required `approved` boolean field - the API returns `approved must be a boolean`

Fixed both to match the actual API contract. The negotiate skill (skill/negotiate.md) already documented these correctly - this was just AGENTS.md being stale.

Verified: full E2E flow works on production with the corrected payloads.