### PR TITLE
fix: handle Vercel free-tier rate limits gracefully in deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,4 +34,14 @@ jobs:
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy to Vercel
-        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: |
+          OUTPUT=$(vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }} 2>&1) && echo "$OUTPUT" || {
+            if echo "$OUTPUT" | grep -q "api-deployments-free-per-day"; then
+              echo "::warning::Vercel free-tier deployment limit reached. Will retry on next schedule."
+              echo "$OUTPUT"
+              exit 0
+            else
+              echo "$OUTPUT"
+              exit 1
+            fi
+          }


### PR DESCRIPTION
## Problem

The deploy workflow fails with exit code 1 when Vercel's free-tier limit (100 deployments/day) is hit. This is happening because Vercel's git integration auto-deploys on every push to main, consuming most of the quota before the scheduled deploy workflow runs.

## Fix

When the deploy step encounters `api-deployments-free-per-day`, it now:
- Logs a warning (visible in GitHub Actions)
- Exits 0 instead of 1

This prevents noisy red X failures on the deploy workflow.

## Note

The root cause is that Vercel git integration + the deploy workflow are both deploying. Consider disabling Vercel git auto-deploy and relying solely on the workflow (see #166).