### PR TITLE
fix: deploy workflow rate-limit handling with bash {0}

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,14 +34,17 @@ jobs:
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy to Vercel
+        shell: bash {0}
         run: |
-          OUTPUT=$(vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }} 2>&1) && echo "$OUTPUT" || {
-            if echo "$OUTPUT" | grep -q "api-deployments-free-per-day"; then
-              echo "::warning::Vercel free-tier deployment limit reached. Will retry on next schedule."
-              echo "$OUTPUT"
-              exit 0
-            else
-              echo "$OUTPUT"
-              exit 1
-            fi
-          }
+          vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }} 2>&1 | tee /tmp/deploy-output.txt
+          EXIT_CODE=${PIPESTATUS[0]}
+          if [ "$EXIT_CODE" -eq 0 ]; then
+            echo "Deploy succeeded."
+            exit 0
+          fi
+          if grep -q "api-deployments-free-per-day" /tmp/deploy-output.txt; then
+            echo "::warning::Vercel free-tier deployment limit reached. Will retry on next schedule."
+            exit 0
+          fi
+          echo "Deploy failed with exit code $EXIT_CODE"
+          exit 1


### PR DESCRIPTION
## Problem

PR #167 added rate-limit handling to the deploy workflow, but it never actually worked. The deploy step kept failing with exit code 1 even when hitting the Vercel free-tier limit.

**Root cause:** GitHub Actions uses `shell: /usr/bin/bash -e {0}` by default. With `set -e`, the command substitution `OUTPUT=$(vercel deploy ... 2>&1)` exits the shell immediately when the inner command fails - before the `||` branch can execute.

## Fix

- Use `shell: bash {0}` to disable errexit
- Pipe output through `tee` for reliable capture
- Check `PIPESTATUS[0]` for the real exit code
- Grep the captured output for rate-limit errors

## Testing

Verified the bash logic locally. The previous approach silently failed on every rate-limited deploy since #167 was merged.