### PR TITLE
fix: make /docs page publicly accessible

### DIFF
--- a/src/__tests__/proxy.test.ts
+++ b/src/__tests__/proxy.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from "vitest";
 
 // Mirror the proxy logic for testing
-const PUBLIC_ANY_METHOD = ["/", "/login", "/register", "/api/register", "/api/login"];
+const PUBLIC_ANY_METHOD = ["/", "/login", "/register", "/docs", "/api/register", "/api/login"];
 const PUBLIC_GET_ONLY = [
   "/api/stats",
   "/api/categories",
@@ -41,6 +41,7 @@ describe("proxy public paths", () => {
     expect(isPublicPath("/", "GET")).toBe(true);
     expect(isPublicPath("/login", "GET")).toBe(true);
     expect(isPublicPath("/register", "GET")).toBe(true);
+    expect(isPublicPath("/docs", "GET")).toBe(true);
     expect(isPublicPath("/browse", "GET")).toBe(true);
     expect(isPublicPath("/browse/listing-123", "GET")).toBe(true);
   });

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3,7 +3,7 @@ import { hashSessionToken, SESSION_COOKIE_NAME } from "@/lib/auth";
 import { ensureDb } from "@/lib/db";
 
 // Paths accessible without auth for any method (auth endpoints that need POST)
-const PUBLIC_ANY_METHOD = ["/", "/login", "/register", "/api/register", "/api/login"];
+const PUBLIC_ANY_METHOD = ["/", "/login", "/register", "/docs", "/api/register", "/api/login"];
 // Paths accessible without auth for GET only (read-only discovery)
 const PUBLIC_GET_ONLY = [
   "/api/stats",


### PR DESCRIPTION
## Problem
`/docs` redirects to `/login` in production because it's not in the proxy's public path list. Documentation should be accessible without authentication.

## Fix
Added `/docs` to `PUBLIC_ANY_METHOD` in `src/proxy.ts` and updated the mirrored list in the proxy test.

## Testing
- All 549 tests pass
- Typecheck clean
- Verified locally that `/docs` returns 200 without auth