### PR TITLE
fix: restrict deal details to participants only

### DIFF
--- a/src/__tests__/api-deals.test.ts
+++ b/src/__tests__/api-deals.test.ts
@@ -171,9 +171,9 @@ describe("GET /api/deals", () => {
 });
 
 describe("GET /api/deals/:matchId", () => {
-  it("returns deal detail with profiles", async () => {
+  it("returns deal detail with profiles for participant", async () => {
     const { matchId } = await createMatchedPair();
-    const res = await dealDetailGET(jsonReq(`/api/deals/${matchId}`), {
+    const res = await dealDetailGET(jsonReq(`/api/deals/${matchId}`, undefined, aliceKey), {
       params: Promise.resolve({ matchId }),
     });
     const data = await res.json();
@@ -183,10 +183,27 @@ describe("GET /api/deals/:matchId", () => {
   });
 
   it("returns 404 for non-existent deal", async () => {
-    const res = await dealDetailGET(jsonReq("/api/deals/nonexistent"), {
+    const res = await dealDetailGET(jsonReq("/api/deals/nonexistent", undefined, aliceKey), {
       params: Promise.resolve({ matchId: "nonexistent" }),
     });
     expect(res.status).toBe(404);
+  });
+
+  it("returns 403 for non-participant", async () => {
+    const { matchId } = await createMatchedPair();
+    const charlieKey = await getApiKey("charlie");
+    const res = await dealDetailGET(jsonReq(`/api/deals/${matchId}`, undefined, charlieKey), {
+      params: Promise.resolve({ matchId }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 401 without auth", async () => {
+    const { matchId } = await createMatchedPair();
+    const res = await dealDetailGET(jsonReq(`/api/deals/${matchId}`), {
+      params: Promise.resolve({ matchId }),
+    });
+    expect(res.status).toBe(401);
   });
 });
 

--- a/src/__tests__/skill-integration.test.ts
+++ b/src/__tests__/skill-integration.test.ts
@@ -389,7 +389,7 @@ describe("Skill Doc Integration: Full Agent Lifecycle", () => {
 
     // === Phase 4: Get deal context ===
     // Skill doc format: { match: { id, status, overlap, profiles: { a, b } }, messages, approvals }
-    const dealRes = await dealDetailGET(req(`/api/deals/${matchId}`), {
+    const dealRes = await dealDetailGET(req(`/api/deals/${matchId}`, { apiKey: aliceKey }), {
       params: Promise.resolve({ matchId }),
     });
     expect(dealRes.status).toBe(200);
@@ -449,7 +449,7 @@ describe("Skill Doc Integration: Full Agent Lifecycle", () => {
     expect(msg2Res.status).toBe(200);
 
     // Read messages - verify skill doc format
-    const dealAfterMsgs = await dealDetailGET(req(`/api/deals/${matchId}`), {
+    const dealAfterMsgs = await dealDetailGET(req(`/api/deals/${matchId}`, { apiKey: aliceKey }), {
       params: Promise.resolve({ matchId }),
     });
     const msgsData = await dealAfterMsgs.json();

--- a/src/app/api/deals/[matchId]/route.ts
+++ b/src/app/api/deals/[matchId]/route.ts
@@ -1,8 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { ensureDb } from "@/lib/db";
+import { authenticateAny } from "@/lib/auth";
 import type { Match, Message, Approval, Profile } from "@/lib/types";
 
-export async function GET(_req: NextRequest, { params }: { params: Promise<{ matchId: string }> }) {
+export async function GET(req: NextRequest, { params }: { params: Promise<{ matchId: string }> }) {
+  const auth = await authenticateAny(req);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   const { matchId } = await params;
 
   const db = await ensureDb();
@@ -27,6 +33,27 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ mat
     args: [match.profile_b_id],
   });
   const profileB = profileBResult.rows[0] as unknown as Profile;
+
+  // Verify the authenticated user is a participant in this deal
+  const isParticipant =
+    profileA?.agent_id === auth.agent_id || profileB?.agent_id === auth.agent_id;
+
+  // For session-cookie auth (browser), check if user owns either agent
+  let isOwner = false;
+  if (!isParticipant && auth.user_id) {
+    const ownerCheck = await db.execute({
+      sql: "SELECT 1 FROM api_keys WHERE user_id = ? AND agent_id IN (?, ?)",
+      args: [auth.user_id, profileA?.agent_id ?? "", profileB?.agent_id ?? ""],
+    });
+    isOwner = ownerCheck.rows.length > 0;
+  }
+
+  if (!isParticipant && !isOwner) {
+    return NextResponse.json(
+      { error: "Forbidden: you are not a participant in this deal" },
+      { status: 403 },
+    );
+  }
 
   const messagesResult = await db.execute({
     sql: "SELECT * FROM messages WHERE match_id = ? ORDER BY created_at ASC",


### PR DESCRIPTION
Closes #176

## Problem

`GET /api/deals/:matchId` returned full deal details (messages, proposed terms, approvals) to **any authenticated user**, even non-participants. This leaks sensitive negotiation data.

## Fix

- Added `authenticateAny()` call to the deal detail endpoint
- Verify the caller's `agent_id` matches one of the deal's participants
- For session-cookie auth (browser), check if the user owns an API key for either participant agent
- Non-participants get 403, unauthenticated get 401

## Tests

- Added: 403 for non-participant accessing deal details
- Added: 401 for unauthenticated access
- Updated existing deal detail test to pass auth
- Updated skill integration test to pass auth headers
- 552 tests passing, typecheck clean