### PR TITLE
fix: expand admin purge patterns for cron/maint/notif test accounts

### DIFF
--- a/src/__tests__/api-admin-purge.test.ts
+++ b/src/__tests__/api-admin-purge.test.ts
@@ -113,6 +113,27 @@ describe("Admin Purge", () => {
     expect(data.purged).not.toContain("real-agent");
   });
 
+  it("purges cron-test and maint-* accounts by pattern", async () => {
+    await seedTestUser("cron-test-1771193729");
+    await seedTestUser("maint-dbg-1771189195");
+    await seedTestUser("maint-e2e-a-1771189078");
+    await seedTestUser("maint-inbox-1771189114");
+    await seedTestUser("maint-notif-a-1771189180");
+    await seedTestUser("notif-dev");
+    await seedTestUser("real-agent");
+
+    const res = await POST(makeReq(undefined, ADMIN_SECRET));
+    const data = await res.json();
+
+    expect(data.purged).toContain("cron-test-1771193729");
+    expect(data.purged).toContain("maint-dbg-1771189195");
+    expect(data.purged).toContain("maint-e2e-a-1771189078");
+    expect(data.purged).toContain("maint-inbox-1771189114");
+    expect(data.purged).toContain("maint-notif-a-1771189180");
+    expect(data.purged).toContain("notif-dev");
+    expect(data.purged).not.toContain("real-agent");
+  });
+
   it("returns empty array when no matches", async () => {
     await seedTestUser("real-agent");
     const res = await POST(makeReq(undefined, ADMIN_SECRET));

--- a/src/app/api/admin/purge/route.ts
+++ b/src/app/api/admin/purge/route.ts
@@ -44,14 +44,19 @@ export async function POST(req: NextRequest) {
           username LIKE 'lobsterbot%' OR
           username LIKE 'clientbot%' OR
           username LIKE 'testbot%' OR
-          username LIKE 'maint-test-%' OR
+          username LIKE 'maint-%' OR
           username LIKE 'mfix-%' OR
           username LIKE 'devcheck%' OR
           username LIKE 'devtest%' OR
           username LIKE 'flowtest-%' OR
           username LIKE 'dbg-%' OR
           username LIKE 'agent-dev%' OR
-          username LIKE 'agent-client%'`,
+          username LIKE 'agent-client%' OR
+          username LIKE 'cron-test-%' OR
+          username LIKE 'notif-%' OR
+          username LIKE 'rawtest%' OR
+          username LIKE 'edev%' OR
+          username LIKE 'eclient%'`,
       );
       usernames = result.rows.map((r) => String(r.username));
     }


### PR DESCRIPTION
Production had accumulated test accounts from cron dev sessions that didn't match existing purge patterns (cron-test-*, maint-dbg-*, maint-e2e-*, notif-*, etc).

**Changes:**
- Broadened `maint-test-%` to `maint-%` to catch all maintenance test variants
- Added patterns: `cron-test-%`, `notif-%`, `rawtest%`, `edev%`, `eclient%`
- New test covering the expanded patterns

**Test:** 553 tests passing, typecheck clean.