### PR TITLE
fix: reconnect auth middleware to Next.js runtime

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,1 @@
+export { proxy as middleware, config } from "@/proxy";


### PR DESCRIPTION
Fixes #188

## Problem

When `middleware.ts` was renamed to `proxy.ts` in PR #52 ('Next.js 16 compatibility'), Next.js stopped auto-discovering it. Next.js only loads middleware from `middleware.ts` / `middleware.js` - naming it `proxy.ts` effectively disabled all auth middleware.

## Impact

- `/docs` and `/browse` redirect to `/login` inconsistently in production (cached Vercel edge artifacts from when middleware was active)
- Auth enforcement is unreliable

## Fix

Add `src/middleware.ts` that re-exports the proxy function with the correct name:

```ts
export { proxy as middleware, config } from '@/proxy';
```

This keeps all auth logic in `proxy.ts` (unchanged) while reconnecting it to Next.js's middleware system.

## Tests

- 556 tests pass
- TypeScript clean