### PR TITLE
fix: remove standalone output that breaks proxy.ts auth in production

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,5 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {
-  output: "standalone",
-};
+const nextConfig: NextConfig = {};
 
 export default nextConfig;


### PR DESCRIPTION
Fixes #188

## Problem

`output: 'standalone'` in next.config.ts prevents Next.js 16 from properly registering proxy.ts as middleware in production builds. The middleware manifest shows empty `{}` even though the build says 'ƒ Proxy (Middleware)'.

This causes /docs to redirect to /login on Vercel despite being in `PUBLIC_ANY_METHOD`.

## Root Cause

Next.js 16 introduced `proxy.ts` as a replacement for `middleware.ts`. The dev server handles it correctly, but the production build combined with `output: 'standalone'` skips middleware registration.

## Fix

Remove `output: 'standalone'` from next.config.ts. Vercel doesn't use standalone output anyway - it has its own build adapter.

## Verified

- Production build (`bun run build && bun run start`): /docs → 200, /browse → 200, /dashboard → 307 (correct auth redirect)
- 554 tests passing
- Typecheck clean
- Build succeeds with proxy middleware registered