### PR TITLE
chore: expand admin purge patterns for crontest/ptest/lt test accounts

### DIFF
--- a/src/app/api/admin/purge/route.ts
+++ b/src/app/api/admin/purge/route.ts
@@ -56,7 +56,11 @@ export async function POST(req: NextRequest) {
           username LIKE 'notif-%' OR
           username LIKE 'rawtest%' OR
           username LIKE 'edev%' OR
-          username LIKE 'eclient%'`,
+          username LIKE 'eclient%' OR
+          username LIKE 'crontest%' OR
+          username LIKE 'ptest-%' OR
+          username LIKE 'lt-%' OR
+          username LIKE 'localtest-%'`,
       );
       usernames = result.rows.map((r) => String(r.username));
     }


### PR DESCRIPTION
Adds missing purge patterns for test accounts created during cron E2E testing sessions:
- `crontest%`
- `ptest-%`
- `lt-%`
- `localtest-%`

These accounts accumulate in production from automated maintenance sessions.